### PR TITLE
Gather all errors top down

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -201,7 +201,7 @@ createAppContext cliOptions@CLIOptions{..} logger = do
                 & #lmdbSize .~ lmdbRealSize        
     }
 
-    logDebugM logger [i|Created application context: #{config appContext}|]
+    logInfoM logger [i|Created application context: #{config appContext}|]
     pure appContext    
 
 

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -469,9 +469,8 @@ saveDelta appContext repoUri notification currentSerial deltaContent = do
                             DB.putObject tx objectStore so worldVersion                      
                             DB.linkObjectToUrl tx objectStore rpkiUrl hash'
                             addedObject
-                _ -> do 
-                    -- it can't happen in practice
-                    pure ()
+                other -> 
+                    logDebugM logger [i|Weird thing happened in `addObject` #{other}.|]
 
         replaceObject objectStore tx uri a oldHash = do            
             waitTask a >>= \case
@@ -479,7 +478,7 @@ saveDelta appContext repoUri notification currentSerial deltaContent = do
                     logErrorM logger [i|Skipped object #{uri}, error #{e} |]
                     inSubVPath (unURI uri) $ appWarn e 
                 DecodingTrouble rpkiUrl (VErr e) -> do
-                    logErrorM logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]                    
+                    logErrorM logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
                     inSubVPath (unURI $ getURL rpkiUrl) $ appError e                                           
                 ASN1ParsingTrouble rpkiUrl (VErr e) -> do
                     logErrorM logger [i|Couldn't parse object #{uri}, error #{e} |]
@@ -505,9 +504,9 @@ saveDelta appContext repoUri notification currentSerial deltaContent = do
                             DB.linkObjectToUrl tx objectStore rpkiUrl hash'
                             addedObject
 
-                _ -> do 
-                    -- it can't happen in practice
-                    pure ()
+                other -> 
+                    logDebugM logger [i|Weird thing happened in `replaceObject` #{other}.|]
+                    
                                                                                   
 
     logger          = appContext ^. typed @AppLogger           
@@ -526,6 +525,7 @@ data ObjectProcessingResult =
         | HashExists RpkiURL Hash
         | ASN1ParsingTrouble RpkiURL VProblem
         | Success RpkiURL (StorableObject RpkiObject)
+    deriving Show
 
 data DeltaOp m a = Delete URI Hash 
                 | Add URI (Task m a) 

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -22,7 +22,7 @@ import           Data.Generics.Product.Fields
 import           GHC.Generics (Generic)
 
 
-import           Data.Either                      (fromRight)
+import           Data.Either                      (fromRight, partitionEithers)
 import           Data.Foldable
 import qualified Data.Set.NonEmpty                as NESet
 import           Data.Map.Strict                  (Map)
@@ -453,9 +453,9 @@ validateCaCertificate
                                 -- gather all the validation states from every mft entry
                                 mapM_ (embedState . snd) mftEntryResults                
 
-                                case [ e | (Left e, _) <- mftEntryResults ] of 
-                                    []    -> pure [ vrps | (Right vrps, _) <- mftEntryResults ]
-                                    e : _ -> appError e                                
+                                case partitionEithers $ map fst mftEntryResults of
+                                    ([], vrps) -> pure vrps
+                                    (e : _, _) -> appError e
 
                         mconcat <$> processChildren `finallyError` markAllEntriesAsVisited                                                
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -55,6 +55,7 @@ extra-deps:
       - co-log-core
       - co-log
   - hw-ip-2.4.2.0
+  - warp-3.3.17
   - servant-cassava-0.10@sha256:9edd9b59aa5013c829cc25b67d25dc3c3a7185926f2c59006a38a9ae405d9658,1686
   - prometheus-metrics-ghc-1.0.1.1@sha256:d378a7186a967140fe0e09d325fe5e3bfd7b77a1123934b40f81fdfed2eacbdc,1233
   - monoidal-containers-0.6.0.1@sha256:f56ea8fe91ff93da140e38b8dab4b94437b901818c13ba72fc7fc802290323ee,2583


### PR DESCRIPTION
When validating a manifest, gather all the errors instead of failing on the very first one. The result (set of VRPs) will be the same, but it's better for logging and UI to give full set of errors.