### PR TITLE
Rfc6486 latest bis

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -390,7 +390,7 @@ data CLIOptions wrapped = CLIOptions {
         "Don't fetch repositories, expect all the objects to be cached (mostly used for testing, default is false).",
 
     strictManifestValidation :: wrapped ::: Bool <?> 
-        "Use the strict version of RFC 6486 (https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/) for manifest handling (default is false)."
+        "Use the strict version of RFC 6486 (https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/ item 6.4) for manifest handling (default is false)."
 
 } deriving (Generic)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -195,7 +195,8 @@ createAppContext cliOptions@CLIOptions{..} logger = do
                 & maybeSet (#validationConfig . #rrdpRepositoryRefreshInterval) (Seconds <$> rrdpRefreshInterval)
                 & maybeSet (#validationConfig . #rsyncRepositoryRefreshInterval) (Seconds <$> rsyncRefreshInterval)
                 & #validationConfig . #dontFetch .~ dontFetch                
-                & #validationConfig . #strictManifest .~ strictManifest                
+                & #validationConfig . #manifestProcessing .~ 
+                        (if strictManifest then RFC6486_Strict else RFC6486)
                 & maybeSet (#httpApiConf . #port) httpApiPort
                 & #rtrConfig .~ rtrConfig
                 & maybeSet #cacheLifeTime ((\hours -> Seconds (hours * 60 * 60)) <$> cacheLifetimeHours)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -195,6 +195,7 @@ createAppContext cliOptions@CLIOptions{..} logger = do
                 & maybeSet (#validationConfig . #rrdpRepositoryRefreshInterval) (Seconds <$> rrdpRefreshInterval)
                 & maybeSet (#validationConfig . #rsyncRepositoryRefreshInterval) (Seconds <$> rsyncRefreshInterval)
                 & #validationConfig . #dontFetch .~ dontFetch                
+                & #validationConfig . #strictManifest .~ strictManifest                
                 & maybeSet (#httpApiConf . #port) httpApiPort
                 & #rtrConfig .~ rtrConfig
                 & maybeSet #cacheLifeTime ((\hours -> Seconds (hours * 60 * 60)) <$> cacheLifetimeHours)
@@ -385,7 +386,10 @@ data CLIOptions wrapped = CLIOptions {
         "Log level, may be 'error', 'warn', 'info', 'debug' (case-insensitive). Default is 'info'.",
 
     dontFetch :: wrapped ::: Bool <?> 
-        "Don't fetch repositories, expect all the objects to be cached (mostly used for testing, default is false)."
+        "Don't fetch repositories, expect all the objects to be cached (mostly used for testing, default is false).",
+
+    strictManifest :: wrapped ::: Bool <?> 
+        "Use the strict version of RFC 6486 (https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/) for manifest handling (default is false)."
 
 } deriving (Generic)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -196,7 +196,7 @@ createAppContext cliOptions@CLIOptions{..} logger = do
                 & maybeSet (#validationConfig . #rsyncRepositoryRefreshInterval) (Seconds <$> rsyncRefreshInterval)
                 & #validationConfig . #dontFetch .~ dontFetch                
                 & #validationConfig . #manifestProcessing .~ 
-                        (if strictManifest then RFC6486_Strict else RFC6486)
+                        (if strictManifestValidation then RFC6486_Strict else RFC6486)
                 & maybeSet (#httpApiConf . #port) httpApiPort
                 & #rtrConfig .~ rtrConfig
                 & maybeSet #cacheLifeTime ((\hours -> Seconds (hours * 60 * 60)) <$> cacheLifetimeHours)
@@ -389,7 +389,7 @@ data CLIOptions wrapped = CLIOptions {
     dontFetch :: wrapped ::: Bool <?> 
         "Don't fetch repositories, expect all the objects to be cached (mostly used for testing, default is false).",
 
-    strictManifest :: wrapped ::: Bool <?> 
+    strictManifestValidation :: wrapped ::: Bool <?> 
         "Use the strict version of RFC 6486 (https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/) for manifest handling (default is false)."
 
 } deriving (Generic)

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -56,12 +56,15 @@ data RrdpConf = RrdpConf {
     rrdpTimeout :: Seconds
 } deriving stock (Show, Eq, Ord, Generic)
 
+data ManifestProcessing = RFC6486_Strict | RFC6486
+    deriving stock (Show, Eq, Ord, Generic)
+
 data ValidationConfig = ValidationConfig {
     revalidationInterval           :: Seconds,
     rrdpRepositoryRefreshInterval  :: Seconds,
     rsyncRepositoryRefreshInterval :: Seconds,    
     dontFetch                      :: Bool,
-    strictManifest                 :: Bool
+    manifestProcessing             :: ManifestProcessing
 } deriving stock (Show, Eq, Ord, Generic)
 
 data HttpApiConfig = HttpApiConfig {
@@ -100,7 +103,7 @@ defaultConfig = Config {
         rrdpRepositoryRefreshInterval  = Seconds 120,
         rsyncRepositoryRefreshInterval = Seconds $ 11 * 60,    
         dontFetch                      = False,
-        strictManifest                 = False
+        manifestProcessing             = RFC6486
     },
     httpApiConf = HttpApiConfig {
         port = 9999

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -60,7 +60,8 @@ data ValidationConfig = ValidationConfig {
     revalidationInterval           :: Seconds,
     rrdpRepositoryRefreshInterval  :: Seconds,
     rsyncRepositoryRefreshInterval :: Seconds,    
-    dontFetch                      :: Bool
+    dontFetch                      :: Bool,
+    strictManifest                 :: Bool
 } deriving stock (Show, Eq, Ord, Generic)
 
 data HttpApiConfig = HttpApiConfig {
@@ -98,7 +99,8 @@ defaultConfig = Config {
         revalidationInterval           = Seconds $ 13 * 60,
         rrdpRepositoryRefreshInterval  = Seconds 120,
         rsyncRepositoryRefreshInterval = Seconds $ 11 * 60,    
-        dontFetch                      = False
+        dontFetch                      = False,
+        strictManifest                 = False
     },
     httpApiConf = HttpApiConfig {
         port = 9999

--- a/src/RPKI/Http/Messages.hs
+++ b/src/RPKI/Http/Messages.hs
@@ -157,7 +157,8 @@ toValidationMessage = \case
           
       CertWrongPolicyExtension b -> [i|Certificate policy extension is broken: #{b}.|]
 
-      ObjectHasMultipleLocations-> [i|The same object has multiple locations, this is suspicious.|]
+      ObjectHasMultipleLocations locs -> 
+          [i|The same object has multiple locations #{fmtUrlList locs}, this is suspicious.|]
 
       NoMFT aki _ -> 
           [i|No manifest found for #{aki}.|]
@@ -239,6 +240,9 @@ toValidationMessage = \case
       RoaPrefixLenghtsIsBiggerThanMaxLength (Vrp _ prefix maxLength) -> 
           [i|VRP is malformed, length of the prefix #{prefix} is bigger than #{maxLength}.|]
   where
+    fmtUrlList = mconcat . 
+                 List.intersperse "," . map show  
+
     fmtMftEntries = mconcat . 
                     List.intersperse "," . 
                     map (\(T2 t h) -> t <> Text.pack (":" <> show h))

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -52,7 +52,7 @@ data ValidationError =  SPKIMismatch EncodedBase64 EncodedBase64 |
                         TACertAKIIsNotEmpty URI |
                         CertNoPolicyExtension |
                         CertWrongPolicyExtension BS.ByteString |
-                        ObjectHasMultipleLocations |
+                        ObjectHasMultipleLocations [RpkiURL] |
                         NoMFT AKI Locations |
                         NoCRLOnMFT AKI Locations |
                         MoreThanOneCRLOnMFT AKI Locations [T2 Text Hash] |

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -442,10 +442,31 @@ validateCaCertificate
                         vp <- askEnv
                         let processChildren = do 
                                 -- this indicates the difeerence between RFC6486-bis 
-                                -- version 02 (strict) and version 03 (more loose)                            
+                                -- version 02 (strict) and version 03 and later (more loose).                                                                                            
                                 let gatherMftEntryValidations = 
-                                        case config ^. #validationConfig . #manifestProcessing of                                            
-                                            RFC6486        -> independentMftChildrenResults
+                                        case config ^. #validationConfig . #manifestProcessing of
+                                            {- 
+                                            The latest version so far of the 
+                                            https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/06/                                            
+                                            item 6.4 says
+                                                "If there are files listed in the manifest that cannot be retrieved 
+                                                from the publication point, the fetch has failed.." 
+
+                                            For that case validity of every object on the manifest is completely 
+                                            separate from each other and don't influence the manifest validity.
+                                            -}
+                                            RFC6486 -> independentMftChildrenResults
+
+                                            {- 
+                                            https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/
+                                            item 6.4 says
+                                                "If there are files listed in the manifest that cannot be retrieved 
+                                                from the publication point, or if they fail the validity tests 
+                                                specified in [RFC6488], the fetch has failed...". 
+
+                                            For that case invalidity of some of the objects (all except certificates) 
+                                            on the manifest make the whole manifest invalid.
+                                            -}
                                             RFC6486_Strict -> allOrNothingMftChildrenResults
 
                                 useMftEntryResults =<< gatherMftEntryValidations nonCrlChildren validCrl                                                                       

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -499,13 +499,13 @@ validateCaCertificate
                 case r of 
                     Left e   -> pure (Left e, vs)
                     Right ro -> do 
-                        (z, q) <- runValidatorT vp $ validateMftObject ro hash' filename validCrl
+                        (z, vs') <- runValidatorT vp $ validateMftObject ro hash' filename validCrl
                         pure $ case z of 
                             -- We are cheating here, by replacing the individual
                             -- MFT entry validation error with empty set of VRPs.
-                            -- The error will be inside of `vs` anyway.
-                            Left _ -> (Right mempty, q)
-                            _      -> (z, q)     
+                            -- The error will be in the `vs'` anyway.
+                            Left _ -> (Right mempty, vs')
+                            _      -> (z, vs')     
 
     useMftEntryResults mftEntryResults = do                 
         -- gather all the validation states from every MFT entry

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -442,26 +442,15 @@ validateCaCertificate
                         vp <- askEnv
                         let processChildren = 
                                 case config ^. #validationConfig . #manifestProcessing of
-                                    RFC6486_Strict -> do 
-
-                                        -- we do all this fiddling here to gather _all_ errors from the manifest
-                                        -- instead of stopping at the first one as it would normally happen with 
-                                        -- validation errors.
-                                        mftEntryResults <- liftIO $ inParallel
-                                                (cpuBottleneck appBottlenecks <> ioBottleneck appBottlenecks)
-                                                nonCrlChildren
-                                                $ \(T2 filename hash') -> runValidatorT vp 
-                                                    $ validateManifestEntry filename hash' validCrl  
-                                        
-                                        -- gather all the validation states from every mft entry
-                                        mapM_ (embedState . snd) mftEntryResults                
-
-                                        case partitionEithers $ map fst mftEntryResults of
-                                            ([], vrps) -> pure vrps
-                                            (e : _, _) -> appError e
-
-                                    RFC6486 -> do  
-                                        pure mempty
+                                    -- this indicates the difeerence between RFC6486-bis 
+                                    -- version 02 (strict) and version 03 (more loose)
+                                    RFC6486_Strict -> do
+                                        -- in this case 
+                                        rs <- allOrNothingMftChildrenResults nonCrlChildren validCrl
+                                        mftChildrenValidation rs
+                                    RFC6486 -> do
+                                        rs <- independentMftChildrenResults nonCrlChildren validCrl
+                                        mftChildrenValidation rs
 
                         mconcat <$> processChildren `finallyError` markAllEntriesAsVisited                                                
 
@@ -471,7 +460,41 @@ validateCaCertificate
             oneMoreMft
             addValidMft topDownContext childrenAki mft
             pure manifestResult            
+    
+    allOrNothingMftChildrenResults nonCrlChildren validCrl = do
+        vp <- askEnv
+        liftIO $ inParallel
+            (cpuBottleneck appBottlenecks <> ioBottleneck appBottlenecks)
+            nonCrlChildren
+            $ \(T2 filename hash') -> runValidatorT vp $ do 
+                    ro <- findManifestEntryObject filename hash' 
+                    validateMftObject ro hash' filename validCrl                
 
+    independentMftChildrenResults nonCrlChildren validCrl = do
+        vp <- askEnv
+        liftIO $ inParallel
+            (cpuBottleneck appBottlenecks <> ioBottleneck appBottlenecks)
+            nonCrlChildren
+            $ \(T2 filename hash') -> do 
+                (r, vs) <- runValidatorT vp $ findManifestEntryObject filename hash' 
+                case r of 
+                    Left e   -> pure (Left e, vs)
+                    Right ro -> do 
+                        (z, q) <- runValidatorT vp $ validateMftObject ro hash' filename validCrl
+                        pure $ case z of 
+                            -- We are cheating here, by replacing the individual
+                            -- MFT entry validation error with empty set of VRPs.
+                            -- The error will be inside of `vs` anyway.
+                            Left _ -> (Right mempty, q)
+                            _      -> (z, q)     
+
+    mftChildrenValidation mftEntryResults = do                 
+        -- gather all the validation states from every MFT entry
+        mapM_ (embedState . snd) mftEntryResults                
+
+        case partitionEithers $ map fst mftEntryResults of
+            ([], vrps) -> pure vrps
+            (e : _, _) -> appError e
 
     -- Check manifest entries as a whole, without doing anything 
     -- with the objects they are pointing to.    
@@ -493,49 +516,46 @@ validateCaCertificate
             longerThanOne [_] = False
             longerThanOne []  = False            
             longerThanOne _   = True
-        
-        
-    --
-    -- | Validate an entry of the manifest, i.e. a pair of filename and hash
-    -- 
-    validateManifestEntry filename hash' validCrl = do                    
-        validateMftFileName        
-        
+
+
+    validateMftObject ro hash' filename validCrl = do
+        -- warn about names on the manifest mismatching names in the object URLs
+        let objectLocations = getLocations ro
+        let nameMatches = NESet.filter ((filename `Text.isSuffixOf`) . toText) $ unLocations objectLocations
+        when (null nameMatches) $ 
+            vWarn $ ManifestLocationMismatch filename objectLocations
+
+        -- Validate the MFT entry, i.e. validate a ROA/GBR/etc.
+        -- or recursively validate CA if the child is a certificate.                           
+        validateChild validCrl ro
+
+    
+    findManifestEntryObject filename hash' = do                    
+        validateMftFileName filename                         
         ro <- liftIO $ do 
             objectStore' <- (^. #objectStore) <$> readTVarIO database
             roTx objectStore' $ \tx -> getByHash tx objectStore' hash'
-
         case ro of 
-            Nothing -> 
-                vError $ ManifestEntryDoesn'tExist hash' filename
-            Just ro' -> do
-                -- warn about names on the manifest mismatching names in the object URLs
-                let objectLocations = getLocations ro'
-                let nameMatches = NESet.filter ((filename `Text.isSuffixOf`) . toText) $ unLocations objectLocations
-                when (null nameMatches) $ 
-                    vWarn $ ManifestLocationMismatch filename objectLocations
+            Nothing  -> vError $ ManifestEntryDoesn'tExist hash' filename
+            Just ro' -> pure ro'
 
-                -- Validate the MFT entry, i.e. validate a ROA/GBR/etc.
-                -- or recursively validate CA if the child is a certificate.                           
-                validateChild validCrl ro'
-      where 
 
-        allowedMftFileNameCharacters = ['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'] <> "-_"
-        validateMftFileName =                
-            case Text.splitOn "." filename of 
-                [ mainName, extension ] -> do                    
-                    unless (isSupportedExtension $ Text.toLower extension) $ 
-                        vError $ BadFileNameOnMFT filename 
-                                    ("Unsupported filename extension " <> extension)
-
-                    unless (Text.all (`elem` allowedMftFileNameCharacters) mainName) $ do 
-                        let badChars = Text.filter (`notElem` allowedMftFileNameCharacters) mainName
-                        vError $ BadFileNameOnMFT filename 
-                                    ("Unsupported characters in filename: '" <> badChars <> "'")
-
-                somethingElse -> 
+    allowedMftFileNameCharacters = ['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'] <> "-_"
+    validateMftFileName filename =                
+        case Text.splitOn "." filename of 
+            [ mainName, extension ] -> do                    
+                unless (isSupportedExtension $ Text.toLower extension) $ 
                     vError $ BadFileNameOnMFT filename 
-                                "Filename doesn't have exactly one DOT"            
+                                ("Unsupported filename extension " <> extension)
+
+                unless (Text.all (`elem` allowedMftFileNameCharacters) mainName) $ do 
+                    let badChars = Text.filter (`notElem` allowedMftFileNameCharacters) mainName
+                    vError $ BadFileNameOnMFT filename 
+                                ("Unsupported characters in filename: '" <> badChars <> "'")
+
+            somethingElse -> 
+                vError $ BadFileNameOnMFT filename 
+                            "Filename doesn't have exactly one DOT"            
 
     
     validateChild validCrl child@(Located locations ro) = do
@@ -632,7 +652,7 @@ validateCaCertificate
     validateObjectLocations (getLocations -> locs@(Locations locSet)) =
         inSubVPath (locationsToText locs) $ 
             when (NESet.size locSet > 1) $ 
-                vWarn ObjectHasMultipleLocations    
+                vWarn $ ObjectHasMultipleLocations $ neSetToList locSet
 
     -- | Check that CRL URL in the certificate is the same as the one 
     -- the CRL was actually fetched from. 


### PR DESCRIPTION
This is to implement a switch to validate manifest entries according to 
https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/02/ (strictest possible) 
and more loose validation according to the later versions of the same RFC.