### PR TITLE
WIP: Use processes for isolation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -69,7 +69,7 @@ import           RPKI.SLURM.SlurmProcessing
 
 import           RPKI.RRDP.RrdpFetch
 
-import           RPKI.Process
+import           RPKI.Worker
 import           RPKI.TAL
 import           RPKI.Util               (convert, fmtEx)
 import           RPKI.Workflow

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -364,17 +364,17 @@ getRootDirectory CLIOptions{..} =
         s  -> Just $ Prelude.last s
         
 
--- This is for worker processes
+-- This is for worker processes.
 executeWorker :: WorkerInput 
             -> AppLmdbEnv 
             -> IO ()
 executeWorker input appContext = 
-    executeWork input $ \_ ->   
+    executeWork input $ \_ returnResult ->   
         case input ^. #params of
             RrdpFetchParams {..} -> do
                 z <- runValidatorT validatorPath $ 
                             updateObjectForRrdpRepository appContext worldVersion rrdpRepository                            
-                writeWorkerOutput $ RrdpFetchResult z
+                returnResult $ RrdpFetchResult z
             CompactionParams {..} -> do 
                 z <- copyLmdbEnvironment appContext targetLmdbEnv                
                 writeWorkerOutput $ CompactionResult z

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -275,8 +275,8 @@ initialiseFS cliOptions logger = do
                                         [i|Error downloading TAL #{tal} from #{talUrl}|]
                                         [i|Http status #{unHttpStatus httpStatus}|]
             case r of
-                Left e ->
-                    logErrorM logger [i|Failed to initialise: #{e}. |] <>
+                Left e -> do
+                    logErrorM logger [i|Failed to initialise: #{e}.|]
                     logErrorM logger [i|Please read https://github.com/lolepezy/rpki-prover/blob/master/README.md for the instructions on how to fix it manually.|]
                 Right _ ->
                     logInfoM logger [i|Done.|]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -99,7 +99,7 @@ mainProcess cliOptions = do
 
 inProcess :: CLIOptions Unwrapped -> IO ()
 inProcess cliOptions@CLIOptions{..} =
-    if not (isJust worker)
+    if isNothing worker
         then do             
             mainProcess cliOptions
         else do         

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -399,7 +399,7 @@ executeWork input appContext =
             threadDelay 500_000                
 
     timeoutWait = do
-        let Timeout (Seconds s) = input ^. #workerTimeout
+        let Timebox (Seconds s) = input ^. #workerTimeout
         threadDelay $ 1_000_000 * fromIntegral s        
         exitWith exitTimeout
    
@@ -474,11 +474,11 @@ data CLIOptions wrapped = CLIOptions {
        +++ "in seconds (default is 11 minutes, i.e. 660 seconds)"),
 
     rrdpTimeout :: wrapped ::: Maybe Int64 <?>
-        ("Timeout for RRDP repositories, in seconds. If fetching of a repository does not "
+        ("Timebox for RRDP repositories, in seconds. If fetching of a repository does not "
        +++ "finish within this timeout, the repository is considered unavailable"),
 
     rsyncTimeout :: wrapped ::: Maybe Int64 <?>
-        ("Timeout for rsync repositories, in seconds. If fetching of a repository does not "
+        ("Timebox for rsync repositories, in seconds. If fetching of a repository does not "
        +++ "finish within this timeout, the repository is considered unavailable"),
 
     httpApiPort :: wrapped ::: Maybe Word16 <?>

--- a/mem/MemLeaker.hs
+++ b/mem/MemLeaker.hs
@@ -76,7 +76,7 @@ main = do
                 let now = versionToMoment worldVersion
                 let cacheLifeTime = appContext ^. typed @Config ^. #cacheLifeTime
                 (results, elapsed) <- timedMS $
-                    inParallel
+                    inParallelOrdered
                         (appContext ^. #appBottlenecks . #cpuBottleneck 
                          <> appContext ^. #appBottlenecks . #ioBottleneck) 
                     -- forConcurrently

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
 - directory
 - filepath
 - file-embed-lzma
+- FindBin
 - generic-lens
 - generic-monoid
 - hexpat

--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,6 @@ dependencies:
 - directory
 - filepath
 - file-embed-lzma
-- FindBin
 - generic-lens
 - generic-monoid
 - hexpat
@@ -184,7 +183,7 @@ tests:
     ghc-options:
     - -threaded
     - -rtsopts
-    - '"-with-rtsopts=-A24m -AL128m -N -s"'
+    - '"-with-rtsopts=-A24m -AL128m -N2 -qg -T --disable-delayed-os-memory-return"'
     - -Wall
     - -O2
     dependencies:

--- a/src/RPKI/AppContext.hs
+++ b/src/RPKI/AppContext.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE StrictData         #-}
 
 module RPKI.AppContext where
+    
 import           Control.Concurrent.STM (TVar)
 import           GHC.Generics
 import           RPKI.AppState
 import           RPKI.Config
-import           RPKI.Repository
 import           RPKI.Logging
 import           RPKI.Parallel
 import           RPKI.Store.Database

--- a/src/RPKI/AppMonad.hs
+++ b/src/RPKI/AppMonad.hs
@@ -20,10 +20,10 @@ import           Data.Generics.Product.Typed
 import           Data.Proxy
 import           Data.Text                   (Text)
 
-import           RPKI.Reporting
-import           RPKI.Time
 import           System.Timeout
 
+import           RPKI.Reporting
+import           RPKI.Time
 
 
 -- Application monad stack

--- a/src/RPKI/AppTypes.hs
+++ b/src/RPKI/AppTypes.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE StrictData         #-}
 
 module RPKI.AppTypes where
+    
 import           Codec.Serialise
 import           Data.Int
 import           GHC.Generics

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE StrictData #-}
 
 module RPKI.Config where
+
+import Codec.Serialise
 
 import GHC.Conc
 import Numeric.Natural
@@ -18,88 +22,105 @@ import RPKI.Util (toNatural)
 import GHC.Generics (Generic)
 
 data Parallelism = Parallelism {
-    cpuCount :: Natural,
-    cpuParallelism :: Natural,
-    ioParallelism :: Natural
-} deriving stock (Show, Eq, Ord, Generic)
+        cpuCount :: Natural,
+        cpuParallelism :: Natural,
+        ioParallelism :: Natural
+    } 
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
 
 data Config = Config {
-    rootDirectory             :: FilePath,
-    talDirectory              :: FilePath,
-    tmpDirectory              :: FilePath,
-    cacheDirectory            :: FilePath,
-    parallelism               :: Parallelism,
-    rsyncConf                 :: RsyncConf,
-    rrdpConf                  :: RrdpConf,
-    validationConfig          :: ValidationConfig,
-    httpApiConf               :: HttpApiConfig,
-    rtrConfig                 :: Maybe RtrConfig,
-    cacheCleanupInterval      :: Seconds,
-    cacheLifeTime             :: Seconds,
-    oldVersionsLifetime       :: Seconds,
-    storageCompactionInterval :: Seconds,
-    lmdbSizeMb                :: Size,
-    localExceptions           :: [FilePath]
-} deriving stock (Show, Eq, Ord, Generic)
+        programBinaryPath         :: FilePath,
+        rootDirectory             :: FilePath,
+        talDirectory              :: FilePath,
+        tmpDirectory              :: FilePath,
+        cacheDirectory            :: FilePath,
+        parallelism               :: Parallelism,
+        rsyncConf                 :: RsyncConf,
+        rrdpConf                  :: RrdpConf,
+        validationConfig          :: ValidationConfig,
+        httpApiConf               :: HttpApiConfig,
+        rtrConfig                 :: Maybe RtrConfig,
+        cacheCleanupInterval      :: Seconds,
+        cacheLifeTime             :: Seconds,
+        oldVersionsLifetime       :: Seconds,
+        storageCompactionInterval :: Seconds,
+        lmdbSizeMb                :: Size,
+        localExceptions           :: [FilePath]
+    } 
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
 
 data RsyncConf = RsyncConf {
-    rsyncRoot    :: FilePath,
-    rsyncTimeout :: Seconds
-} deriving stock (Show, Eq, Ord, Generic)
+        rsyncRoot    :: FilePath,
+        rsyncTimeout :: Seconds
+    } 
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
 
 newtype Size = Size Int64
     deriving stock (Show, Eq, Ord, Generic)
     deriving newtype (Num)
+    deriving anyclass (Serialise)
     deriving Semigroup via Sum Size
     deriving Monoid via Sum Size
 
 data RrdpConf = RrdpConf {
-    tmpRoot     :: FilePath,
-    maxSize     :: Size,
-    rrdpTimeout :: Seconds
-} deriving stock (Show, Eq, Ord, Generic)
+        tmpRoot     :: FilePath,
+        maxSize     :: Size,
+        rrdpTimeout :: Seconds
+    }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
 
 data ManifestProcessing = RFC6486_Strict | RFC6486
-    deriving stock (Show, Eq, Ord, Generic)
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
 
 data ValidationConfig = ValidationConfig {    
-    revalidationInterval           :: Seconds,
-    rrdpRepositoryRefreshInterval  :: Seconds,
-    rsyncRepositoryRefreshInterval :: Seconds,
+        revalidationInterval           :: Seconds,
+        rrdpRepositoryRefreshInterval  :: Seconds,
+        rsyncRepositoryRefreshInterval :: Seconds,
 
-    -- Used mainly for testing and doesn't really make sense
-    -- in a production environment    
-    dontFetch                      :: Bool,
-    
-    manifestProcessing             :: ManifestProcessing,
+        -- Used mainly for testing and doesn't really make sense
+        -- in a production environment    
+        dontFetch                      :: Bool,
+        
+        manifestProcessing             :: ManifestProcessing,
 
-    -- Maximal object tree depth measured in number of CAs
-    maxCertificatePathDepth        :: Int,
+        -- Maximal object tree depth measured in number of CAs
+        maxCertificatePathDepth        :: Int,
 
-    -- How many objects we allow in the tree for one TA.
-    -- There needs to be some finite number to limit total
-    -- tree validation and prevent DOS attacks.
-    maxTotalTreeSize               :: Int,
+        -- How many objects we allow in the tree for one TA.
+        -- There needs to be some finite number to limit total
+        -- tree validation and prevent DOS attacks.
+        maxTotalTreeSize               :: Int,
 
-    -- How many different repositories we allow to add
-    -- during one TA top-down validation
-    maxTaRepositories              :: Int,
+        -- How many different repositories we allow to add
+        -- during one TA top-down validation
+        maxTaRepositories              :: Int,
 
-    -- Maximal allowed size of an individual object 
-    maxObjectSize                  :: Integer,
+        -- Maximal allowed size of an individual object 
+        maxObjectSize                  :: Integer,
 
-    -- Manimal allowed size of an individual object 
-    minObjectSize                  :: Integer
-} deriving stock (Show, Eq, Ord, Generic)
+        -- Manimal allowed size of an individual object 
+        minObjectSize                  :: Integer
+    } 
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
 
 data HttpApiConfig = HttpApiConfig {
-    port :: Word16    
-} deriving stock (Show, Eq, Ord, Generic)
+        port :: Word16    
+    } 
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
 
 data RtrConfig = RtrConfig {
-    rtrAddress :: String,
-    rtrPort    :: Int16
-} deriving stock (Show, Eq, Ord, Generic)
+        rtrAddress :: String,
+        rtrPort    :: Int16
+    } 
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
 
 getRtsCpuCount :: Natural 
 getRtsCpuCount = fromMaybe 1 $ toNatural numCapabilities
@@ -120,6 +141,7 @@ defaultParallelism cpus = Parallelism cpus (2 * cpus) 64
 
 defaultConfig :: Config
 defaultConfig = Config {
+    programBinaryPath = "rpki-prover",
     rootDirectory = "",
     talDirectory = "",
     tmpDirectory = "",

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -54,6 +54,7 @@ data Config = Config {
     deriving anyclass (Serialise)
 
 data RsyncConf = RsyncConf {
+        rsyncClientPath :: Maybe FilePath,
         rsyncRoot    :: FilePath,
         rsyncTimeout :: Seconds
     } 
@@ -150,6 +151,7 @@ defaultConfig = Config {
     cacheDirectory = "",
     parallelism = makeParallelism 2,
     rsyncConf = RsyncConf {
+        rsyncClientPath = Nothing,
         rsyncRoot    = "",
         rsyncTimeout = 7 * 60
     },

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -167,7 +167,9 @@ defaultConfig = Config {
         maxCertificatePathDepth        = 32,
         maxTotalTreeSize               = 5_000_000,
         maxObjectSize                  = 32 * 1024 * 1024,
-        minObjectSize                  = 32,
+        -- every object contains at least 256 bytes of RSA key, 
+        -- couple of dates and a few extenions
+        minObjectSize                  = 300,
         maxTaRepositories              = 1000
     },
     httpApiConf = HttpApiConfig {

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -136,8 +136,8 @@ setCpuCount = setNumCapabilities . fromIntegral
 -- that many IO operations (http downloads, LMDB reads, etc.) at once.
 --
 -- TODO There should be distinction between network operations and file/LMDB IO.
-defaultParallelism :: Natural -> Parallelism
-defaultParallelism cpus = Parallelism cpus (2 * cpus) 64
+makeParallelism :: Natural -> Parallelism
+makeParallelism cpus = Parallelism cpus (2 * cpus) 64
 
 defaultConfig :: Config
 defaultConfig = Config {
@@ -146,7 +146,7 @@ defaultConfig = Config {
     talDirectory = "",
     tmpDirectory = "",
     cacheDirectory = "",
-    parallelism = defaultParallelism 2,
+    parallelism = makeParallelism 2,
     rsyncConf = RsyncConf {
         rsyncRoot    = "",
         rsyncTimeout = 7 * 60

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -18,6 +18,7 @@ import Data.Hourglass
 import Data.Maybe (fromMaybe)
 import Data.Monoid
 
+import RPKI.Logging
 import RPKI.Util (toNatural)
 import GHC.Generics (Generic)
 
@@ -29,7 +30,7 @@ data Parallelism = Parallelism {
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (Serialise)
 
-data Config = Config {
+data Config = Config {        
         programBinaryPath         :: FilePath,
         rootDirectory             :: FilePath,
         talDirectory              :: FilePath,
@@ -46,7 +47,8 @@ data Config = Config {
         oldVersionsLifetime       :: Seconds,
         storageCompactionInterval :: Seconds,
         lmdbSizeMb                :: Size,
-        localExceptions           :: [FilePath]
+        localExceptions           :: [FilePath],
+        logLevel                  :: LogLevel
     } 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (Serialise)
@@ -140,7 +142,7 @@ makeParallelism :: Natural -> Parallelism
 makeParallelism cpus = Parallelism cpus (2 * cpus) 64
 
 defaultConfig :: Config
-defaultConfig = Config {
+defaultConfig = Config {    
     programBinaryPath = "rpki-prover",
     rootDirectory = "",
     talDirectory = "",
@@ -177,7 +179,8 @@ defaultConfig = Config {
     oldVersionsLifetime       = Seconds $ 60 * 60 * 10,
     storageCompactionInterval = Seconds $ 60 * 60 * 24,
     lmdbSizeMb                = Size $ 32 * 1024,
-    localExceptions = []    
+    localExceptions = [],
+    logLevel = defaultsLogLevel
 }
 
 defaultRtrConfig :: RtrConfig

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -23,6 +23,7 @@ data Parallelism = Parallelism {
 } deriving stock (Show, Eq, Ord, Generic)
 
 data Config = Config {
+    rootDirectory             :: FilePath,
     talDirectory              :: FilePath,
     tmpDirectory              :: FilePath,
     cacheDirectory            :: FilePath,
@@ -108,6 +109,7 @@ setCpuCount = setNumCapabilities . fromIntegral
 
 defaultConfig :: Config
 defaultConfig = Config {
+    rootDirectory = "",
     talDirectory = "",
     tmpDirectory = "",
     cacheDirectory = "",

--- a/src/RPKI/Domain.hs
+++ b/src/RPKI/Domain.hs
@@ -31,6 +31,8 @@ import qualified Data.List                as List
 import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import qualified Data.Set                 as Set
+import           Data.Map.Monoidal.Strict (MonoidalMap)
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
 
 import           Data.Monoid.Generic
 import           Data.Tuple.Strict
@@ -494,7 +496,7 @@ newtype TaName = TaName { unTaName :: Text }
 instance Show TaName where
     show = show . unTaName
 
-newtype Vrps = Vrps { unVrps :: Map TaName (Set Vrp) }
+newtype Vrps = Vrps { unVrps :: MonoidalMap TaName (Set Vrp) }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise
     deriving Semigroup via GenericSemigroup Vrps
@@ -633,10 +635,10 @@ makeSerial i =
 
 
 vrpCount :: Vrps -> Int 
-vrpCount (Vrps vrps) = sum $ map Set.size $ Map.elems vrps
+vrpCount (Vrps vrps) = sum $ map Set.size $ MonoidalMap.elems vrps
 
 newVrps :: TaName -> Set Vrp -> Vrps
-newVrps taName vrpSet = Vrps $ Map.singleton taName vrpSet
+newVrps taName vrpSet = Vrps $ MonoidalMap.singleton taName vrpSet
 
 allVrps :: Vrps -> Set Vrp 
-allVrps (Vrps vrps) = mconcat $ Map.elems vrps          
+allVrps (Vrps vrps) = mconcat $ MonoidalMap.elems vrps          

--- a/src/RPKI/Fetch.hs
+++ b/src/RPKI/Fetch.hs
@@ -282,8 +282,7 @@ fetchRepository
             (do
                 (z, elapsed) <- timedMS $ fromTryM 
                                     (RrdpE . UnknownRrdpProblem . fmtEx) 
-                                    -- (updateObjectForRrdpRepository appContext r)
-                                    (runRrdpFetch appContext worldVersion r)
+                                    (runRrdpFetchWorker appContext worldVersion r)
                 logInfoM logger [i|Fetched #{getURL repoURL}, took #{elapsed}ms.|]
                 pure z)            
             (do 

--- a/src/RPKI/Fetch.hs
+++ b/src/RPKI/Fetch.hs
@@ -275,7 +275,8 @@ fetchRepository
             (do
                 (z, elapsed) <- timedMS $ fromTryM 
                                     (RrdpE . UnknownRrdpProblem . fmtEx) 
-                                    (updateObjectForRrdpRepository appContext r)
+                                    -- (updateObjectForRrdpRepository appContext r)
+                                    (runRrdpFetch appContext r)
                 logInfoM logger [i|Fetched #{getURL repoURL}, took #{elapsed}ms.|]
                 pure z)            
             (do 

--- a/src/RPKI/Fetch.hs
+++ b/src/RPKI/Fetch.hs
@@ -106,7 +106,7 @@ fetchPPWithFallback
     funRun runs key = Map.lookup key <$> readTVar runs            
 
     -- Use "run only once" logic for the whole list of PPs
-    fetchOnce parentPath ppAccess =          
+    fetchOnce parentPath ppAccess' =          
         join $ atomically $ do
             pps <- readTVar publicationPoints           
             let ppsKey = ppSeqKey pps 
@@ -119,8 +119,8 @@ fetchPPWithFallback
                     pure $ bracketOnError 
                                 (async $ do 
                                     -- logDebug_ logger [i|ppAccess = #{ppAccess}, ppsKey = #{ppsKey}.|]
-                                    !z <- fetchWithFallback parentPath $ NonEmpty.toList $ unPublicationPointAccess ppAccess
-                                    pure z) 
+                                    evaluate =<< fetchWithFallback parentPath 
+                                                    (NonEmpty.toList $ unPublicationPointAccess ppAccess')) 
                                 (stopAndDrop ppSeqFetchRuns ppsKey) 
                                 (rememberAndWait ppSeqFetchRuns ppsKey)                
       where
@@ -359,8 +359,8 @@ setValidationStateOfFetches repositoryProcessing frs = liftIO $ do
     atomically $ do 
         forM_ frs $ \fr -> do 
             let (u, vs) = case fr of
-                    FetchFailure r vs   -> (r, vs)
-                    FetchSuccess repo vs -> (getRpkiURL repo, vs)        
+                    FetchFailure r vs'    -> (r, vs')
+                    FetchSuccess repo vs' -> (getRpkiURL repo, vs')
                 
             modifyTVar' (repositoryProcessing ^. #indivudualFetchResults)
                         $ Map.insert u vs

--- a/src/RPKI/Fetch.hs
+++ b/src/RPKI/Fetch.hs
@@ -119,7 +119,8 @@ fetchPPWithFallback
                     pure $ bracketOnError 
                                 (async $ do 
                                     -- logDebug_ logger [i|ppAccess = #{ppAccess}, ppsKey = #{ppsKey}.|]
-                                    fetchWithFallback parentPath $ NonEmpty.toList $ unPublicationPointAccess ppAccess) 
+                                    !z <- fetchWithFallback parentPath $ NonEmpty.toList $ unPublicationPointAccess ppAccess
+                                    pure z) 
                                 (stopAndDrop ppSeqFetchRuns ppsKey) 
                                 (rememberAndWait ppSeqFetchRuns ppsKey)                
       where

--- a/src/RPKI/Http/HttpServer.hs
+++ b/src/RPKI/Http/HttpServer.hs
@@ -19,11 +19,10 @@ import           Servant.Server.Generic
 
 import qualified Data.ByteString.Builder          as BS
 
-import           Data.List                        (intersperse)
 import qualified Data.List.NonEmpty               as NonEmpty
 import           Data.Maybe                       (fromMaybe, maybeToList)
 import qualified Data.Set                         as Set
-import qualified Data.Map.Strict                  as Map
+import qualified Data.Map.Monoidal.Strict         as MonoidalMap
 import           Data.Text                       (Text)
 
 import           RPKI.AppContext
@@ -100,7 +99,7 @@ getVRPs AppContext {..} func = do
     pure $ case z of 
         Nothing   -> []
         Just vrps -> [ VrpDto a p len (unTaName ta) | 
-                            (ta, vrpSet) <- Map.toList $ unVrps vrps,
+                            (ta, vrpSet) <- MonoidalMap.toList $ unVrps vrps,
                             Vrp a p len  <- Set.toList vrpSet
                      ]    
 

--- a/src/RPKI/Http/Messages.hs
+++ b/src/RPKI/Http/Messages.hs
@@ -12,15 +12,14 @@ module RPKI.Http.Messages where
 
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-
-import Data.Foldable (toList)
-
-import qualified Data.List          as List
+import qualified Data.List                   as List
 
 import           Data.String.Interpolate.IsString
 import           Data.Tuple.Strict
+
 import           RPKI.Domain                 as Domain
 import           RPKI.Reporting
+import           RPKI.Util (fmtLocations)
 
 
 toMessage :: AppError -> Text
@@ -35,8 +34,8 @@ toMessage = \case
     StorageE (StorageError t) -> t
     StorageE (DeserialisationError t) -> t
 
-    SlurmE r -> toSlurmMessage r
-    InternalE (InternalError t) -> t
+    SlurmE r    -> toSlurmMessage r
+    InternalE t -> toInternalErrorMessage t
     
     UnspecifiedE context e -> 
         [i|Unspecified error #{context}, details: #{e}.|]
@@ -270,9 +269,7 @@ toSlurmMessage = \case
     SlurmParseError file t -> [i|Failed to parse SLURM file #{file}: #{t}.|]
     SlurmValidationError t -> [i|Invalid SLURM file(s): #{t}.|]
 
-fmtLocations :: Locations -> Text
-fmtLocations = mconcat . 
-               List.intersperse "," . 
-               map (Text.pack . show) . 
-               toList . 
-               unLocations
+toInternalErrorMessage :: InternalError -> Text
+toInternalErrorMessage = \case 
+    InternalError t -> [i|Internal error: #{t}.|]
+    WorkerTimeout t -> [i|Worker timeout: #{t}.|]    

--- a/src/RPKI/Http/Messages.hs
+++ b/src/RPKI/Http/Messages.hs
@@ -30,10 +30,13 @@ toMessage = \case
     RrdpE r  -> toRrdpMessage r
     RsyncE r -> toRsyncMessage r
     TAL_E (TALError t) -> t
-    InitE (InitError t) -> t
+    InitE (InitError t) -> t    
     
     StorageE (StorageError t) -> t
     StorageE (DeserialisationError t) -> t
+
+    SlurmE r -> toSlurmMessage r
+    InternalE (InternalError t) -> t
     
     UnspecifiedE context e -> 
         [i|Unspecified error #{context}, details: #{e}.|]
@@ -260,6 +263,12 @@ toValidationMessage = \case
                     List.intersperse "," . 
                     map (\(h, fs) -> Text.pack $ "Hash: " <> show h <> " -> " <> show fs)
 
+
+toSlurmMessage :: SlurmError -> Text
+toSlurmMessage = \case 
+    SlurmFileError file t  -> [i|Failed to read SLURM file #{file}: #{t}.|]
+    SlurmParseError file t -> [i|Failed to parse SLURM file #{file}: #{t}.|]
+    SlurmValidationError t -> [i|Invalid SLURM file(s): #{t}.|]
 
 fmtLocations :: Locations -> Text
 fmtLocations = mconcat . 

--- a/src/RPKI/Http/Messages.hs
+++ b/src/RPKI/Http/Messages.hs
@@ -271,5 +271,6 @@ toSlurmMessage = \case
 
 toInternalErrorMessage :: InternalError -> Text
 toInternalErrorMessage = \case 
-    InternalError t -> [i|Internal error: #{t}.|]
-    WorkerTimeout t -> [i|Worker timeout: #{t}.|]    
+    InternalError t     -> t
+    WorkerTimeout t     -> t
+    WorkerOutOfMemory t -> t

--- a/src/RPKI/Http/UI.hs
+++ b/src/RPKI/Http/UI.hs
@@ -203,7 +203,7 @@ validaionDetailsHtml result =
                 tr $ td ! colspan "2" $                                         
                     H.div ! class_ "flex switch" $ do                        
                         H.div ! class_ "ta-header" $ do 
-                            toHtml ta
+                            toHtml ta >> ":"
                             space >> space >> space
                             let (e, w) = countProblems vrs
                             toHtml e >> " errors, "

--- a/src/RPKI/Logging.hs
+++ b/src/RPKI/Logging.hs
@@ -54,17 +54,17 @@ logDebugM logger t = liftIO $ logDebug_ logger t
 
 
 withMainAppLogger :: LogLevel -> (AppLogger -> LoggerT Text IO a) -> IO a
-withMainAppLogger logLevel f = withLogger logLevel stdout f  
+withMainAppLogger logLevel f = withLogger logLevel (stdout, logTextStdout) f  
 
 withWorkerLogger :: LogLevel -> (AppLogger -> LoggerT Text IO a) -> IO a
-withWorkerLogger logLevel f = withLogger logLevel stderr f  
+withWorkerLogger logLevel f = withLogger logLevel (stderr, logTextStderr) f  
 
-withLogger :: LogLevel -> Handle -> (AppLogger -> LoggerT Text IO a) -> IO a
-withLogger logLevel stream f = do     
+withLogger :: LogLevel -> (Handle, LogAction IO Text) -> (AppLogger -> LoggerT Text IO a) -> IO a
+withLogger logLevel (stream, streamLogger) f = do     
     hSetBuffering stream LineBuffering
     withBackgroundLogger
         defCapacity
-        logTextStdout
+        streamLogger
         (\logg -> usingLoggerT logg $ f $ AppLogger logLevel (fullMessageAction logg))
   where
     fullMessageAction logg = upgradeMessageAction defaultFieldMap $ 

--- a/src/RPKI/Orphans/Json.hs
+++ b/src/RPKI/Orphans/Json.hs
@@ -203,6 +203,7 @@ instance ToJSON X509.RevokedCertificate
 instance ToJSON a => ToJSON (X509.SignedExact a)    
 instance ToJSON a => ToJSON (X509.Signed a) 
     
+instance ToJSON NullParam
 instance ToJSON SignatureALG
 
 instance ToJSON Date

--- a/src/RPKI/Orphans/Json.hs
+++ b/src/RPKI/Orphans/Json.hs
@@ -62,6 +62,7 @@ instance ToJSON VProblem
 instance ToJSON VWarning
 instance ToJSON AppError
 instance ToJSON InitError
+instance ToJSON InternalError
 instance ToJSON SlurmError
 instance ToJSON  a => ToJSON (ParseError a)
 instance ToJSON ValidationError

--- a/src/RPKI/Orphans/Serialise.hs
+++ b/src/RPKI/Orphans/Serialise.hs
@@ -36,6 +36,8 @@ import qualified Crypto.PubKey.Ed448 as E448
 
 import Crypto.PubKey.ECC.Types
 
+import System.Posix.Types
+
 import RPKI.Orphans.Generics
 
 instance Serialise X509.Certificate
@@ -108,3 +110,10 @@ deriving instance (Ord a, Serialise a) => Serialise (NESet a)
 deriving instance (Ord a, Serialise a, Serialise b) => Serialise (MonoidalMap a b)
 
 deriving instance (Serialise a, Serialise b) => Serialise (These a b)
+
+
+instance (Serialise CPid) where
+    encode (CPid i) = encode i
+    decode = CPid <$> decode
+
+

--- a/src/RPKI/Orphans/Serialise.hs
+++ b/src/RPKI/Orphans/Serialise.hs
@@ -46,6 +46,7 @@ instance Serialise X509.RevokedCertificate
 instance Serialise a => Serialise (X509.SignedExact a)    
 instance Serialise a => Serialise (X509.Signed a) 
     
+instance Serialise NullParam 
 instance Serialise SignatureALG
 
 instance Serialise DateTime

--- a/src/RPKI/Parallel.hs
+++ b/src/RPKI/Parallel.hs
@@ -299,7 +299,10 @@ concurrentTasks v1 v2 = do
 
 data Slot = Free | Taken | NotForTaking
 
-
+-- | Compute a function for a list of inputs in parallel using the bottleneck.
+-- The otder of the results in the list will be corresponding to the ordere of 
+-- the inputs, moreover, they will be execited more or less "in order".
+-- 
 inParallelOrdered :: Bottleneck 
                     -> [a] 
                     -> (a -> IO b) 
@@ -344,7 +347,10 @@ inParallelOrdered bottleneck as f = do
                 rest <- readAll queue 
                 pure $! z : rest                    
 
-
+-- | Compute a function for a list of inputs in parallel using the bottleneck.
+-- The otder of the results in the list is random and based on how fast each 
+-- of the inputs is processed.
+-- 
 inParallelUnordered :: 
                     Bottleneck 
                     -> [a]

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -120,7 +120,8 @@ workerLogMessage workerId stderr elapsed =
     let workerLog = 
             if LBS.null stderr 
                 then "" 
-                else [i|, <worker-log> 
+                else [i|, 
+<worker-log> 
 #{textual stderr}
 </worker-log>|]            
             in [i|Worker #{workerId} done, took #{elapsed}ms#{workerLog}|]  

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedLabels     #-}
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings    #-}
+
+module RPKI.Process where
+
+import           Codec.Serialise
+
+import           Control.Concurrent.Async.Lifted
+import           Control.Concurrent.Lifted
+import           Control.Concurrent.STM
+import           Control.Exception.Lifted
+import           Control.Monad
+
+import           Control.Lens                     ((^.), (%~), (&))
+import           Data.Generics.Product.Typed
+
+import qualified Data.ByteString.Lazy as LBS
+
+import           Data.Int                         (Int64)
+
+import           Data.Hourglass
+import           Data.String.Interpolate.IsString
+
+import           Data.Text                        (Text)
+import qualified Data.Text                        as Text
+
+import           GHC.Generics
+
+import           System.Exit
+import           System.Process.Typed
+import           System.Environment.FindBin
+
+import           RPKI.AppState
+import           RPKI.AppMonad
+import           RPKI.AppTypes
+import           RPKI.Config
+import           RPKI.Domain
+import           RPKI.Reporting
+import           RPKI.Logging
+import           RPKI.Parallel
+import           RPKI.Store.Database
+import           RPKI.TopDown
+
+import           RPKI.AppContext
+import           RPKI.Metrics
+import           RPKI.RTR.RtrServer
+import           RPKI.Store.Base.Storage
+import           RPKI.TAL
+import           RPKI.Time
+
+import           RPKI.Store.Base.LMDB
+import           RPKI.Store.AppStorage
+import           RPKI.Util (ifJust)
+
+
+data SubProcess = RrdpFetch | Validator | Compaction
+
+data SubProcessInput = SubProcessInput Text
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
+
+
+runSubProcess :: (Serialise a, Serialise r) => 
+                AppContext s 
+            -> a
+            -> [String] 
+            -> IO (r, LBS.ByteString)
+  
+runSubProcess AppContext {..} argument cli = do     
+    let subProcess = 
+            setStdin (byteStringInput $ serialise argument) $             
+                proc __Bin__ 
+                    $ [ "--rpki-root-directory",  config ^. typed @Config . #rootDirectory ] <> cli
+
+    (exitCode, out, err) <- readProcess subProcess
+    let r = deserialise out
+
+    case exitCode of  
+        ExitFailure errorCode -> do
+            pure (r, err)
+        ExitSuccess -> do
+            pure (r, err)
+
+    pure (r, err)
+

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -18,6 +18,8 @@ import           Control.Monad.IO.Class
 import           Control.Lens                     ((^.), (%~), (&))
 
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Text (Text)
+import           Data.String
 import           Data.String.Interpolate.IsString
 
 import           GHC.Generics
@@ -112,3 +114,13 @@ rtsN n = "-N" <> show n
 
 parentDied :: ExitCode
 parentDied = ExitFailure 11
+
+workerLogMessage :: (Show t, Show s, IsString s) => s -> LBS.ByteString -> t -> s
+workerLogMessage workerId stderr elapsed = 
+    let workerLog = 
+            if LBS.null stderr 
+                then "" 
+                else [i|, <worker-log> 
+#{textual stderr}
+</worker-log>|]            
+            in [i|Worker #{workerId} done, took #{elapsed}ms#{workerLog}|]  

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -15,7 +15,7 @@ import           Codec.Serialise
 import           Control.Exception.Lifted
 import           Control.Monad.IO.Class
 
-import           Control.Lens                     ((^.), (%~), (&))
+import           Control.Lens ((^.))
 
 import qualified Data.ByteString.Lazy as LBS
 import           Data.String
@@ -34,7 +34,7 @@ import           RPKI.Config
 import           RPKI.Reporting
 import           RPKI.Repository
 import           RPKI.Logging
-import           RPKI.Util (fmtEx, textual)
+import           RPKI.Util (fmtEx, textual, trimmed)
 
 
 data WorkerParams = RrdpFetchParams { 
@@ -77,7 +77,7 @@ runWorker logger config1 params extraCli = do
             setStdin (byteStringInput stdin) $             
                 proc binaryToRun $ [ "--worker" ] <> extraCli
 
-    logDebugM logger [i|Running worker: #{[ binaryToRun ] <> [ "--worker" ] <> extraCli}|]    
+    logDebugM logger [i|Running worker: #{trimmed worker}|]    
 
     z <- liftIO $ try $ readProcess worker
     case z of 
@@ -117,7 +117,7 @@ workerLogMessage :: (Show t, Show s, IsString s) => s -> LBS.ByteString -> t -> 
 workerLogMessage workerId stderr elapsed = 
     let workerLog = 
             if LBS.null stderr 
-                then "" 
+                then "" :: String
                 else [i|, 
 <worker-log> 
 #{textual stderr}</worker-log>|]            

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -18,7 +18,6 @@ import           Control.Monad.IO.Class
 import           Control.Lens                     ((^.), (%~), (&))
 
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Text (Text)
 import           Data.String
 import           Data.String.Interpolate.IsString
 
@@ -29,7 +28,6 @@ import           System.Process.Typed
 import           System.Posix.Types
 import           System.Posix.Process
 
-import           RPKI.AppContext
 import           RPKI.AppMonad
 import           RPKI.AppTypes
 import           RPKI.Config
@@ -122,6 +120,5 @@ workerLogMessage workerId stderr elapsed =
                 then "" 
                 else [i|, 
 <worker-log> 
-#{textual stderr}
-</worker-log>|]            
+#{textual stderr}</worker-log>|]            
             in [i|Worker #{workerId} done, took #{elapsed}ms#{workerLog}|]  

--- a/src/RPKI/Process.hs
+++ b/src/RPKI/Process.hs
@@ -47,13 +47,6 @@ import           RPKI.Store.AppStorage
 import           RPKI.Util (ifJust, fmtEx)
 
 
--- data WorkerInput = WorkerInput Text
---     deriving stock (Eq, Ord, Show, Generic)
---     deriving anyclass (Serialise)
-
-data ProcessError = ProcessError Text
-
-
 runWorker :: (Serialise r, Show r) => 
             AppContext s -> 
                 Config
@@ -66,7 +59,7 @@ runWorker AppContext {..} config1 argument worldVersion extraCli = do
     let stdin = serialise (argument, worldVersion, config1)
     let worker = 
             setStdin (byteStringInput stdin) $             
-                proc binaryToRun $  [ "--worker" ] <> extraCli
+                proc binaryToRun $ [ "--worker" ] <> extraCli
 
     logDebugM logger [i|Running worker: #{worker}|]    
 
@@ -100,14 +93,6 @@ data WorkerParams = RrdpFetchParams {
             }
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (Serialise)
-
--- workerType :: WorkerParams -> String
--- workerType RrdpFetchParams {..}  = "rrdp-fetch"
--- workerType CompactionParams {..} = "compaction"
-
--- getWorkerType "rrdp-fetch" = Right RrdpFetch
--- getWorkerType "compaction" = Right Compaction
--- getWorkerType t            = Left $ "Unknown sub-process: " <> show t
 
 rtsArguments args = [ "+RTS" ] <> args <> [ "-RTS" ]
 

--- a/src/RPKI/RRDP/Http.hs
+++ b/src/RPKI/RRDP/Http.hs
@@ -59,13 +59,13 @@ instance Blob LBS.ByteString where
 
 instance Blob BS.ByteString where    
     sizeB = Size . fromIntegral . BS.length 
-    readB f s = 
+    readB f _ = mapFile f
         -- if s < 50_000_000 
             -- read relatively small files in memory entirely
             -- and mmap bigger ones.
             -- then fsRead f
             -- else 
-                mapFile f
+                
 
 
 -- | Download HTTP content to a temporary file and return the context as lazy/strict ByteString. 

--- a/src/RPKI/RRDP/Http.hs
+++ b/src/RPKI/RRDP/Http.hs
@@ -60,11 +60,12 @@ instance Blob LBS.ByteString where
 instance Blob BS.ByteString where    
     sizeB = Size . fromIntegral . BS.length 
     readB f s = 
-        if s < 50_000_000 
+        -- if s < 50_000_000 
             -- read relatively small files in memory entirely
             -- and mmap bigger ones.
-            then fsRead f
-            else mapFile f
+            -- then fsRead f
+            -- else 
+                mapFile f
 
 
 -- | Download HTTP content to a temporary file and return the context as lazy/strict ByteString. 

--- a/src/RPKI/RRDP/Parse/Xeno.hs
+++ b/src/RPKI/RRDP/Parse/Xeno.hs
@@ -117,7 +117,7 @@ parseSnapshot bs = runST $ do
     let snapshotPublishes = do
             ps <- (lift . readSTRef) publishes
             pure $ map (\(uri, base64) -> 
-                        SnapshotPublish (URI $ convert uri) (EncodedBase64 $ removeSpaces base64))
+                        SnapshotPublish (URI $ convert uri) (EncodedBase64 $ trim base64))
                         $ reverse ps
 
     let snapshot = Snapshot <$>
@@ -190,7 +190,7 @@ parseDelta bs = runST $ do
                     Left  (uri, hash) -> 
                         DW $ DeltaWithdraw (URI $ convert uri) hash                
                     Right (uri, hash, base64) -> 
-                        DP $ DeltaPublish (URI $ convert uri) hash (EncodedBase64 $ removeSpaces base64))
+                        DP $ DeltaPublish (URI $ convert uri) hash (EncodedBase64 $ trim base64))
                     $ reverse is
 
 

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -32,7 +32,7 @@ import           RPKI.Config
 import           RPKI.Domain
 import           RPKI.Reporting
 import           RPKI.Logging
-import           RPKI.Process
+import           RPKI.Worker
 import           RPKI.Parallel
 import           RPKI.Parse.Parse
 import           RPKI.Repository

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -70,7 +70,7 @@ runRrdpFetchWorker AppContext {..} worldVersion repository = do
                                 logger
                                 config 
                                 (RrdpFetchParams vp repository worldVersion)                        
-                                (Timeout $ config ^. typed @RrdpConf . #rrdpTimeout)
+                                (Timebox $ config ^. typed @RrdpConf . #rrdpTimeout)
                                 arguments                        
     embedState vs
     case z of 

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -50,11 +50,11 @@ import qualified RPKI.Util                        as U
 
 
 
-runRrdpFetch :: AppContext s 
+runRrdpFetchWorker :: AppContext s 
             -> WorldVersion
             -> RrdpRepository             
             -> ValidatorT IO RrdpRepository
-runRrdpFetch appContext@AppContext {..} worldVersion repository = do
+runRrdpFetchWorker appContext@AppContext {..} worldVersion repository = do
 
     -- Do not allow fetch process to have more than 4 CPUs to avoid memory bloat.
     let maxCpuPerFetch = 4    

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -388,8 +388,8 @@ saveSnapshot appContext worldVersion repoUri notification snapshotContent = do
         waitTask a >>= \case     
             HashExists rpkiURL hash ->
                 DB.linkObjectToUrl tx objectStore rpkiURL hash
-            UnparsableRpkiURL uri (VWarn (VWarning e)) -> do                    
-                logErrorM logger [i|Skipped object #{uri}, error #{e} |]
+            UnparsableRpkiURL rpkiUrl (VWarn (VWarning e)) -> do                    
+                logErrorM logger [i|Skipped object #{rpkiUrl}, error #{e} |]
                 inSubVPath (unURI uri) $ appWarn e 
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logErrorM logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
@@ -446,9 +446,9 @@ saveDelta appContext worldVersion repoUri notification currentSerial deltaConten
     when (currentSerial /= serial) $
         appError $ RrdpE $ DeltaSerialMismatch serial notificationSerial
     
-    let savingTx serial f = 
+    let savingTx serial' f = 
             rwAppTx objectStore $ \tx -> 
-                f tx >> RS.updateRrdpMeta tx repositoryStore (sessionId, serial) repoUri 
+                f tx >> RS.updateRrdpMeta tx repositoryStore (sessionId, serial') repoUri 
 
     -- Propagate exceptions from here, anything that can happen here 
     -- (storage failure, file read failure) should stop the validation and 
@@ -510,8 +510,8 @@ saveDelta appContext worldVersion repoUri notification currentSerial deltaConten
 
     addObject objectStore tx uri a =
         waitTask a >>= \case
-            UnparsableRpkiURL uri (VWarn (VWarning e)) -> do
-                logErrorM logger [i|Skipped object #{uri}, error #{e} |]
+            UnparsableRpkiURL rpkiUrl (VWarn (VWarning e)) -> do
+                logErrorM logger [i|Skipped object #{rpkiUrl}, error #{e} |]
                 inSubVPath (unURI uri) $ appWarn e 
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logErrorM logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
@@ -534,8 +534,8 @@ saveDelta appContext worldVersion repoUri notification currentSerial deltaConten
 
     replaceObject objectStore tx uri a oldHash = do            
         waitTask a >>= \case
-            UnparsableRpkiURL uri (VWarn (VWarning e)) -> do
-                logErrorM logger [i|Skipped object #{uri}, error #{e} |]
+            UnparsableRpkiURL rpkiUrl (VWarn (VWarning e)) -> do
+                logErrorM logger [i|Skipped object #{rpkiUrl}, error #{e} |]
                 inSubVPath (unURI uri) $ appWarn e 
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logErrorM logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -80,11 +80,7 @@ runRrdpFetch appContext@AppContext {..} worldVersion repository = do
     case z of 
         Left e  -> appError e
         Right r -> do 
-            let formattedWorkerLog =             
-                    [i|Worker #{workerId}> done, took #{elapsed}ms, 
-<worker-log> 
-#{U.textual stderr}</worker-log>|]                
-            logDebugM logger formattedWorkerLog                
+            logDebugM logger $ workerLogMessage (U.convert workerId) stderr elapsed            
             pure r
 
 

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -8,7 +8,7 @@
 module RPKI.RRDP.RrdpFetch where
 
 import           Control.Concurrent.STM           (readTVarIO)
-import           Control.Exception.Lifted         (try, finally)
+import           Control.Exception.Lifted         (finally)
 import           Control.Lens                     ((.~), (%~), (&), (^.))
 import           Control.Monad.Except
 import           Data.Generics.Product.Typed

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -142,17 +142,15 @@ data StorageError = StorageError Text |
 newtype TALError = TALError Text 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise
-    deriving newtype Semigroup
 
 newtype InitError = InitError Text 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise
-    deriving newtype Semigroup
 
-newtype InternalError = InternalError Text 
+data InternalError = WorkerTimeout Text 
+                   | InternalError Text 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise
-    deriving newtype Semigroup
 
 data SlurmError = SlurmFileError Text Text |
                   SlurmParseError Text Text |
@@ -293,10 +291,7 @@ instance Monoid HttpStatus where
     mempty = HttpStatus 200
 
 instance Semigroup HttpStatus where
-    s1 <> s2 
-        | not (isHttpSuccess s2) = s2
-        | not (isHttpSuccess s1) = s1
-        | isHttpSuccess s1 = s2    
+    s1 <> s2 = if isHttpSuccess s1 then s2 else s1
 
 data RrdpSource = RrdpNoUpdate | RrdpDelta | RrdpSnapshot
     deriving stock (Show, Eq, Ord, Generic)

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -149,6 +149,11 @@ newtype InitError = InitError Text
     deriving anyclass Serialise
     deriving newtype Semigroup
 
+newtype InternalError = InternalError Text 
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass Serialise
+    deriving newtype Semigroup
+
 data SlurmError = SlurmFileError Text |
                   SlurmParseError Text |
                   SlurmValidationError Text
@@ -163,6 +168,7 @@ data AppError = ParseE (ParseError Text) |
                 ValidationE ValidationError |
                 InitE InitError |
                 SlurmE SlurmError |
+                InternalE InternalError |
                 UnspecifiedE Text Text
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -154,8 +154,8 @@ newtype InternalError = InternalError Text
     deriving anyclass Serialise
     deriving newtype Semigroup
 
-data SlurmError = SlurmFileError Text |
-                  SlurmParseError Text |
+data SlurmError = SlurmFileError Text Text |
+                  SlurmParseError Text Text |
                   SlurmValidationError Text
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -148,6 +148,7 @@ newtype InitError = InitError Text
     deriving anyclass Serialise
 
 data InternalError = WorkerTimeout Text 
+                   | WorkerOutOfMemory Text 
                    | InternalError Text 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass Serialise

--- a/src/RPKI/Resources/IntervalSet.hs
+++ b/src/RPKI/Resources/IntervalSet.hs
@@ -81,7 +81,7 @@ findFullIntersections a is@(IntervalSet v) =
         | otherwise = 
             case big `intersection` a of
                 [] -> []
-                is -> goBackwards (index - 1) <> [(is, big)]
+                is' -> goBackwards (index - 1) <> [(is', big)]
       where
         big = V.unsafeIndex v index
 

--- a/src/RPKI/Resources/Resources.hs
+++ b/src/RPKI/Resources/Resources.hs
@@ -344,6 +344,6 @@ readIp6 s =
     case Ips.canonicalise (read s) of
         Nothing -> error $ "Invalid IPv6: " <> show s
         Just cb -> case cb of 
-                    IpBlockV4 b -> error $ "Invalid IPv6: " <> show s
+                    IpBlockV4 _ -> error $ "Invalid IPv6: " <> show s
                     IpBlockV6 b -> Ipv6Prefix b    
     

--- a/src/RPKI/Rsync.hs
+++ b/src/RPKI/Rsync.hs
@@ -220,7 +220,9 @@ data RsyncMode = RsyncOneFile | RsyncDirectory
 rsyncProcess :: ValidationConfig -> RsyncURL -> FilePath -> RsyncMode -> ProcessConfig () () ()
 rsyncProcess vc (RsyncURL (URI uri)) destination rsyncMode = 
     proc "rsync" $ 
-        [ "--timeout=300",  "--update",  "--times", "--max-size=" <> show (vc ^. #maxObjectSize) ] <> 
+        [ "--timeout=300",  "--update",  "--times" ] <> 
+        [ "--max-size=" <> show (vc ^. #maxObjectSize) ] <> 
+        [ "--min-size=" <> show (vc ^. #minObjectSize) ] <> 
         extraOptions <> 
         [ Text.unpack uri, destination ]
     where 

--- a/src/RPKI/Rsync.hs
+++ b/src/RPKI/Rsync.hs
@@ -7,7 +7,6 @@
 module RPKI.Rsync where
     
 import           Control.Lens                     ((%~), (&), (+=), (^.))
-import           Data.Generics.Product.Fields
 import           Data.Generics.Product.Typed
 
 import           Data.Bifunctor
@@ -17,7 +16,6 @@ import           Control.Exception.Lifted
 
 import           Control.Monad
 import           Control.Monad.Except
-import           Control.Monad.IO.Class
 
 import qualified Data.ByteString                  as BS
 import           Data.String.Interpolate.IsString
@@ -102,7 +100,7 @@ updateObjectForRsyncRepository
         void $ fromTry (RsyncE . FileReadError . U.fmtEx) $ 
             createDirectoryIfMissing True destination
             
-        logDebugM logger [i|Runnning #{U.trimS $ show rsync}...|]
+        logDebugM logger [i|Runnning #{U.trimmed rsync}...|]
         (exitCode, out, err) <- fromTry 
                 (RsyncE . RsyncRunningError . U.fmtEx) $ 
                 readProcess rsync

--- a/src/RPKI/Rsync.hs
+++ b/src/RPKI/Rsync.hs
@@ -100,7 +100,7 @@ updateObjectForRsyncRepository
         void $ fromTry (RsyncE . FileReadError . U.fmtEx) $ 
             createDirectoryIfMissing True destination
             
-        logDebugM logger [i|Runnning #{U.trimmed rsync}...|]
+        logDebugM logger [i|Runnning #{U.trimmed rsync}|]
         (exitCode, out, err) <- fromTry 
                 (RsyncE . RsyncRunningError . U.fmtEx) $ 
                 readProcess rsync

--- a/src/RPKI/Rsync.hs
+++ b/src/RPKI/Rsync.hs
@@ -102,7 +102,7 @@ updateObjectForRsyncRepository
         void $ fromTry (RsyncE . FileReadError . U.fmtEx) $ 
             createDirectoryIfMissing True destination
             
-        logDebugM logger [i|Runnning #{rsync}...|]
+        logDebugM logger [i|Runnning #{U.trimS $ show rsync}...|]
         (exitCode, out, err) <- fromTry 
                 (RsyncE . RsyncRunningError . U.fmtEx) $ 
                 readProcess rsync

--- a/src/RPKI/SLURM/SlurmProcessing.hs
+++ b/src/RPKI/SLURM/SlurmProcessing.hs
@@ -23,7 +23,7 @@ import           Data.List (nub)
 import           Data.Coerce
 
 import qualified Data.Set as Set
-import qualified Data.Map.Strict as Map
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
 
 import           Data.Aeson as Json
 
@@ -49,9 +49,9 @@ slurmVrpName = TaName "slurm"
 
 applySlurm :: Slurm -> Vrps -> Vrps
 applySlurm slurm (Vrps vrps) = 
-    Vrps $ filteredVrps <> Map.singleton slurmVrpName assertedVrps
+    Vrps $ filteredVrps <> MonoidalMap.singleton slurmVrpName assertedVrps
   where     
-    filteredVrps = Map.map (Set.filter filterFunc) vrps
+    filteredVrps = MonoidalMap.map (Set.filter filterFunc) vrps
 
     assertedVrps = Set.fromList 
         $ map toVrp 

--- a/src/RPKI/SLURM/SlurmProcessing.hs
+++ b/src/RPKI/SLURM/SlurmProcessing.hs
@@ -79,9 +79,9 @@ readSlurmFiles :: [String] -> ValidatorT IO Slurm
 readSlurmFiles slurmFiles = do 
     slurms :: [Slurm] <- 
         forM slurmFiles $ \f -> do
-            s <- fromTry (SlurmE . SlurmFileError . fmtEx) $ LBS.readFile f
+            s <- fromTry (SlurmE . SlurmFileError (Text.pack f) . fmtEx) $ LBS.readFile f
             vHoist $ fromEither 
-                   $ first (SlurmE . SlurmParseError . Text.pack) 
+                   $ first (SlurmE . SlurmParseError (Text.pack f) . Text.pack) 
                    $ Json.eitherDecode s
         
     vHoist $ validateNoOverlaps $ zip slurmFiles slurms

--- a/src/RPKI/Store/AppLmdbStorage.hs
+++ b/src/RPKI/Store/AppLmdbStorage.hs
@@ -284,7 +284,7 @@ runCopyWorker AppContext {..} dbtats targetLmdbPath = do
                                     (CompactionParams targetLmdbPath)                        
                                     -- timebox it to 30 minutes, it should be enough even 
                                     -- for a huge cache on a very slow machine
-                                    (Timeout $ Seconds $ 30 * 60)
+                                    (Timebox $ Seconds $ 30 * 60)
                                     arguments
     case z of 
         Left e  -> do 

--- a/src/RPKI/Store/AppLmdbStorage.hs
+++ b/src/RPKI/Store/AppLmdbStorage.hs
@@ -21,7 +21,7 @@ import           Data.Hourglass
 import           RPKI.AppContext
 import           RPKI.AppMonad
 import           RPKI.Logging
-import           RPKI.Process
+import           RPKI.Worker
 import           RPKI.Reporting
 import           RPKI.Store.Base.LMDB
 import           RPKI.Store.Base.Storage

--- a/src/RPKI/Store/AppLmdbStorage.hs
+++ b/src/RPKI/Store/AppLmdbStorage.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedLabels     #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE QuasiQuotes          #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -9,21 +10,25 @@ module RPKI.Store.AppLmdbStorage where
 
 import           Control.Concurrent.STM
 import           Control.Exception.Lifted
-import           Control.Monad (forM_)
+import           Control.Monad (void)
 import           Control.Monad.IO.Class
 
 import           Control.Lens                     ((^.))
+
+import qualified Data.ByteString.Lazy            as LBS
 
 import           Data.String.Interpolate.IsString
 
 import           RPKI.AppContext
 import           RPKI.AppMonad
 import           RPKI.Logging
+import           RPKI.Process
 import           RPKI.Reporting
 import           RPKI.Store.Base.LMDB
 import           RPKI.Store.Base.Storage
 import qualified RPKI.Store.Database              as DB
 import           RPKI.Store.MakeLmdb
+import           RPKI.Store.Base.Storable
 import           RPKI.Time
 import           RPKI.Util
 
@@ -62,9 +67,9 @@ setupLmdbCache lmdbFlow logger cacheDir lmdbSize = do
     
     currentExists <- liftIO $ doesPathExist currentCache    
     if currentExists 
-        then do
+        then do            
             linkTarget   <- liftIO $ readSymbolicLink currentCache
-            targetExists <- liftIO $ doesPathExist $ cacheDir </> linkTarget            
+            targetExists <- liftIO $ doesPathExist $ cacheDir </> linkTarget                        
             if targetExists 
                 then do 
                     -- We have what we need, but there could still be other directories 
@@ -101,11 +106,39 @@ setupLmdbCache lmdbFlow logger cacheDir lmdbSize = do
                 f /= "current" && (cacheDir </> f) /= linkTarget    
 
 
+-- | The same as `setupLmdbCache` but for the worker process.
+-- It does not do any cleanups and just expecets the proper layout to be in place.
+--
+setupWorkerLmdbCache :: AppLogger -> FilePath -> Size -> ValidatorT IO LmdbEnv
+setupWorkerLmdbCache logger cacheDir lmdbSize = do        
+    currentExists <- liftIO $ doesPathExist currentCache    
+    if currentExists 
+        then do    
+            linkTarget   <- liftIO $ readSymbolicLink currentCache
+            targetExists <- liftIO $ doesPathExist $ cacheDir </> linkTarget
+            if targetExists
+                then createLmdb currentCache
+                else do
+                    let message = [i|#{currentCache} doesn't point to an existing directory, broken LMDB.|]
+                    logErrorM logger message
+                    appError $ InternalE $ InternalError message
+        else do
+            let message = [i|#{currentCache} doesn't exist, bailing out.|]
+            logErrorM logger message
+            appError $ InternalE $ InternalError message
+    where        
+        currentCache = cacheDir </> "current"
+
+        createLmdb lmdbDir' =
+            fromTry (InitE . InitError . fmtEx) $ 
+                mkLmdb lmdbDir' lmdbSize maxReadersDefault    
+        
+
 -- | De-fragment LMDB cache.
 -- 
 -- Since we add and delete a lot of data, LMDB files get bigger and bigger over time.
--- It is hard to say why exactly, but the most logical explanation is that it fails
--- to reuse pages in the file and the file gets highly fragmented.
+-- It is hard to say why exactly, but the most logical explanation is that it can't
+-- reuse pages in the file and the file gets highly fragmented.
 --
 -- In order to mitigate the problem, we do the following
 --  * create a new empty environment
@@ -117,7 +150,7 @@ setupLmdbCache lmdbFlow logger cacheDir lmdbSize = do
 -- and point the `cache/current` symlink to it.
 -- 
 compactStorageWithTmpDir :: AppContext LmdbStorage -> IO ()
-compactStorageWithTmpDir AppContext {..} = do      
+compactStorageWithTmpDir appContext@AppContext {..} = do      
     lmdbEnv <- getEnv . (\d -> storage d :: LmdbStorage) <$> readTVarIO database
     let cacheDir = config ^. #cacheDirectory
     let currentCache = cacheDir </> "current"
@@ -147,27 +180,23 @@ compactStorageWithTmpDir AppContext {..} = do
                 ROEnv nn -> pure nn
 
             
-    let copyToNewEnvironmentAndSwap = do                          
+    let copyToNewEnvironmentAndSwap dbStats = do                          
             oldNativeEnv <- setEnvToReadOnly
 
             -- create new native LMDB environment
-            createDirectory newLmdbDirName
-            logDebug_ logger [i|Created #{newLmdbDirName} for storage copy.|]
-
-            newLmdb      <- mkLmdb newLmdbDirName (config ^. #lmdbSizeMb) maxReadersDefault
-            newNativeEnv <- atomically $ getNativeEnv newLmdb
-
-            stats <- copyEnv oldNativeEnv newNativeEnv
-            forM_ stats $ \(name, bytes) -> 
-                logDebug_ logger [i|Copied #{bytes} bytes for the map '#{name}'.|]
-            logDebug_ logger [i|Copied all data to #{newLmdbDirName}.|]
+            createDirectory newLmdbDirName            
 
             currentLinkTarget <- liftIO $ readSymbolicLink currentCache
+            logDebug_ logger [i|Created #{newLmdbDirName} for storage copy, current one is #{currentLinkTarget}|]
+
+            runCopyWorker appContext dbStats newLmdbDirName                                    
+            logDebug_ logger [i|Copied all data to #{newLmdbDirName}.|]            
 
             -- create a new symlink first and only then atomically rename it into "current"
             createSymbolicLink newLmdbDirName $ cacheDir </> "current.new"
             renamePath (cacheDir </> "current.new") currentCache
 
+            newLmdb <- mkLmdb newLmdbDirName (config ^. #lmdbSizeMb) maxReadersDefault
             newDB <- createDatabase newLmdb
             atomically $ do
                 newNative <- getNativeEnv newLmdb
@@ -182,21 +211,22 @@ compactStorageWithTmpDir AppContext {..} = do
     lmdbFileSize <- fmap sum 
                     $ mapM (getFileSize . (currentCache </>)) =<< listDirectory currentLinkTarget            
     
-    Size dataSize <- fmap DB.totalSpace $ DB.getDbStats =<< readTVarIO database
+    dbStats <- fmap DB.totalStats $ DB.getDbStats =<< readTVarIO database
+    let Size dataSize = dbStats ^. #statKeyBytes + dbStats ^. #statValueBytes    
 
     let fileSizeMb :: Integer = lmdbFileSize `div` (1024 * 1024)
     let dataSizeMb :: Integer = fromIntegral $ dataSize `div` (1024 * 1024)
     if fileSizeMb > (2 * dataSizeMb)    
         then do 
             logDebug_ logger [i|The total data size is #{dataSizeMb}mb, LMDB file size #{fileSizeMb}mb, will perform compaction.|]
-            copyToNewEnvironmentAndSwap `catch` (
+            copyToNewEnvironmentAndSwap dbStats `catch` (
                 \(e :: SomeException) -> do
                     logError_ logger [i|ERROR: #{e}.|]        
                     cleanUpAfterException)            
         else 
             logDebug_ logger [i|The total data size is #{dataSizeMb}mb, LMDB file size #{fileSizeMb}mb, compaction is not needed yet.|]
         
-        
+
 generateLmdbDir :: MonadIO m => FilePath -> m FilePath
 generateLmdbDir cacheDir = do 
     Now now <- thisInstant
@@ -214,3 +244,56 @@ cleanDir d = cleanDirFiltered d (const True)
 closeLmdbStorage :: AppContext LmdbStorage -> IO ()
 closeLmdbStorage AppContext {..} =    
     closeLmdb . unEnv . storage =<< readTVarIO database
+
+
+-- This is called from the worker entry point
+-- 
+copyLmdbEnvironment :: AppContext LmdbStorage -> FilePath -> IO ()
+copyLmdbEnvironment AppContext {..} targetLmdbPath = do         
+    currentEnv <- getEnv . (\d -> storage d :: LmdbStorage) <$> readTVarIO database    
+    newLmdb    <- mkLmdb targetLmdbPath (config ^. #lmdbSizeMb) maxReadersDefault
+    currentNativeEnv <- atomically $ getNativeEnv currentEnv
+    newNativeEnv     <- atomically $ getNativeEnv newLmdb     
+    void $ copyEnv currentNativeEnv newNativeEnv        
+
+
+-- | The only reason to do LMDB copying as a separate worker process is memory.
+-- Even thought is a perfectly streaming-like activity, without enough GC pressure 
+-- it allocates a large heap, so it's .
+-- 
+-- So instead we run a worker process with limited heap that does the copying.
+-- 
+runCopyWorker :: AppContext LmdbStorage -> SStats -> FilePath -> IO ()
+runCopyWorker AppContext {..} dbtats targetLmdbPath = do 
+    let workerId :: String = "lmdb-compaction"
+    
+    let maxMemoryMb = let 
+            Size maxMemory = max (dbtats ^. #statMaxKVBytes * 20) 128 
+            in maxMemory `div` 1024 `div` 1024
+
+    let arguments = 
+            [ workerId ] <>
+            rtsArguments [ rtsN 1, rtsA "20m", rtsAL "64m", rtsMaxMemory (show maxMemoryMb <> "m") ]
+
+    ((z, vs), elapsed) <- timedMS $ 
+                    runValidatorT 
+                        (newValidatorPath "lmdb-compaction-worker") $ 
+                            runWorker 
+                                logger
+                                config
+                                (CompactionParams targetLmdbPath)                        
+                                arguments
+    case z of 
+        Left e  -> do 
+            -- Make it more consistent if it makes sense
+            let message = [i|Failed to run compaction worker: #{e}|]
+            logError_ logger message            
+            throwIO $ AppException $ InternalE $ InternalError message
+        Right (_  :: (), stderr) -> do
+            let workerLog = if LBS.null stderr then "" else 
+                    [i|, <worker-log> 
+#{textual stderr}
+</worker-log>|]            
+            logDebug_ logger [i|Worker #{workerId} done, took #{elapsed}ms#{workerLog}|]                
+            
+    

--- a/src/RPKI/Store/AppStorage.hs
+++ b/src/RPKI/Store/AppStorage.hs
@@ -4,6 +4,8 @@ import           RPKI.AppContext
 import           RPKI.Store.Base.LMDB
 import           RPKI.Store.AppLmdbStorage
 
+type AppLmdbEnv = AppContext LmdbStorage
+
 class MaintainableStorage s where
     runMaintenance :: AppContext s -> IO ()
     closeStorage :: AppContext s -> IO ()

--- a/src/RPKI/Store/Base/LMDB.hs
+++ b/src/RPKI/Store/Base/LMDB.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}
 {-# LANGUAGE RecordWildCards       #-}
@@ -8,15 +10,14 @@
 
 module RPKI.Store.Base.LMDB where
 
+import Codec.Serialise
+
 import Control.Monad (forM, forever)
 import Control.Concurrent.STM
 import Control.Exception
 
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
-
-import Data.Map.Strict ((!?))
-import qualified Data.Map.Strict as Map
 
 import RPKI.Store.Base.Storable
 import RPKI.Store.Base.Storage
@@ -25,6 +26,7 @@ import RPKI.Util
 import Data.IORef
 
 import GHC.TypeLits
+import GHC.Generics
 import Data.Proxy as P
 
 import Lmdb.Connection
@@ -34,9 +36,6 @@ import qualified Lmdb.Multimap as LMMap
 import qualified Lmdb.Types as Lmdb
 
 import Pipes
-import RPKI.Reporting
-import RPKI.Parallel
-
 
 type Env = Lmdb.Environment 'Lmdb.ReadWrite
 type DBMap = Lmdb.Database BS.ByteString BS.ByteString
@@ -202,17 +201,21 @@ getNativeEnv LmdbEnv {..} = do
         ROEnv native -> pure native
         RWEnv native -> pure native
 
-data MapInfo a
-    = Single a
-    | Multi a
-    deriving (Show, Eq, Ord)
+
+data CopyStat = CopyStat { 
+        mapName       :: BS.ByteString, 
+        totalSize     :: Int,
+        maxKVPairSize :: Int
+    }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Serialise)
 
 
 -- | Copy all databases from the from LMDB environment to the other
 -- This is a low-level operation to be used for de-fragmentation.
 -- `dstN` is supposed to be a completely empty environment.
 --
-copyEnv :: Env -> Env -> IO [(BS.ByteString, Int)]
+copyEnv :: Env -> Env -> IO [CopyStat]
 copyEnv srcN dstN = do        
     withROTransaction srcN $ \srcTx -> do       
         withTransaction dstN $ \dstTx -> do                              
@@ -228,12 +231,12 @@ copyEnv srcN dstN = do
                         closeDatabase srcN srcMap
                         srcMap' <- openMultiDatabase srcTx (Just $ convert mapName) defaultMultiDbSettngs
                         dstMap  <- openMultiDatabase dstTx (Just $ convert mapName) defaultMultiDbSettngs
-                        copied <- copyMultiMap srcMap' dstMap srcTx dstTx
-                        pure (mapName, copied)
+                        (copied, max) <- copyMultiMap srcMap' dstMap srcTx dstTx
+                        pure $! CopyStat mapName copied max
                     else do 
                         dstMap <- openDatabase dstTx (Just $ convert mapName) defaultDbSettings
-                        copied <- copyMap srcMap dstMap srcTx dstTx                        
-                        pure (mapName, copied)            
+                        (copied, max) <- copyMap srcMap dstMap srcTx dstTx                        
+                        pure $! CopyStat mapName copied max
     where
         getMapNames tx db =
             withCursor tx db $ \c -> do 
@@ -244,24 +247,33 @@ copyEnv srcN dstN = do
                         lift $ modifyIORef' maps ([name] <>)
                 readIORef maps          
         
-        copyMap srcMap dstMap srcTx dstTx = do 
-            bytes <- newIORef 0
-            withCursor srcTx srcMap $ \c ->                
-                void $ runEffect $ LMap.firstForward c >-> do
-                    forever $ do
-                        Lmdb.KeyValue name value <- await
-                        lift $ LMap.insertSuccess' dstTx dstMap name value
-                        lift $ modifyIORef' bytes (+ (BS.length name + BS.length value))
-            readIORef bytes
-
-        copyMultiMap srcMap dstMap srcTx dstTx = do
-            bytes <- newIORef 0
-            withMultiCursor dstTx dstMap $ \dstC -> 
-                withMultiCursor srcTx srcMap $ \srcC ->                 
-                    void $ runEffect $ LMMap.firstForward srcC >-> do
+        copyMap srcMap dstMap srcTx dstTx = 
+            withKVs $ \bytes maxKV -> do                 
+                withCursor srcTx srcMap $ \c ->                
+                    void $ runEffect $ LMap.firstForward c >-> do
                         forever $ do
                             Lmdb.KeyValue name value <- await
-                            lift $ LMMap.insert dstC name value
-                            lift $ modifyIORef' bytes (+ (BS.length name + BS.length value))
-            readIORef bytes
+                            lift $ LMap.insertSuccess' dstTx dstMap name value
+                            let kvSize = BS.length name + BS.length value
+                            lift $ do 
+                                modifyIORef' bytes ( + kvSize)
+                                modifyIORef' maxKV (max kvSize)
 
+        copyMultiMap srcMap dstMap srcTx dstTx =
+            withKVs $ \bytes maxKV -> do 
+                withMultiCursor dstTx dstMap $ \dstC -> 
+                    withMultiCursor srcTx srcMap $ \srcC ->                 
+                        void $ runEffect $ LMMap.firstForward srcC >-> do
+                            forever $ do
+                                Lmdb.KeyValue name value <- await
+                                lift $ LMMap.insert dstC name value
+                                let kvSize = BS.length name + BS.length value
+                                lift $ do 
+                                    modifyIORef' bytes ( + kvSize)
+                                    modifyIORef' maxKV (max kvSize)
+        
+        withKVs processThem = do 
+            bytes <- newIORef 0
+            maxKV <- newIORef 0
+            processThem bytes maxKV
+            (,) <$> readIORef bytes <*> readIORef maxKV

--- a/src/RPKI/Store/Base/Map.hs
+++ b/src/RPKI/Store/Base/Map.hs
@@ -61,6 +61,6 @@ keys tx (SMap _ s) = S.foldS tx s f []
 
 stats :: (Serialise k, Serialise v) =>
         Tx s m -> SMap name s k v -> IO SStats
-stats tx (SMap _ s) = S.foldS tx s f (SStats 0 0 0)
+stats tx (SMap _ s) = S.foldS tx s f (SStats 0 0 0 0)
     where
         f stat skey svalue = pure $! incrementStats stat skey svalue

--- a/src/RPKI/Store/Base/MultiMap.hs
+++ b/src/RPKI/Store/Base/MultiMap.hs
@@ -54,6 +54,6 @@ all tx (SMultiMap _ s) = reverse <$> S.foldMu tx s f []
 
 stats :: (Serialise k, Serialise v) =>
         Tx s m -> SMultiMap name s k v -> IO SStats
-stats tx (SMultiMap _ s) = S.foldMu tx s f (SStats 0 0 0)
+stats tx (SMultiMap _ s) = S.foldMu tx s f (SStats 0 0 0 0)
     where
         f stat skey svalue = pure $! incrementStats stat skey svalue

--- a/src/RPKI/Store/Base/Storable.hs
+++ b/src/RPKI/Store/Base/Storable.hs
@@ -66,13 +66,21 @@ fromSValue (SValue b) = fromStorable b
 
 data SStats = SStats {
         statSize       :: Size,
-        statKeyBytes   :: Size,
-        statValueBytes :: Size
+        statKeyBytes   :: Size,        
+        statValueBytes :: Size,
+        statMaxKVBytes :: Size
     } 
-    deriving stock (Show, Eq, Generic)
-    deriving Semigroup via GenericSemigroup SStats
+    deriving stock (Show, Eq, Generic)    
     deriving Monoid    via GenericMonoid SStats
 
+instance Semigroup SStats where
+    ss1 <> ss2 = 
+        SStats { 
+            statSize = statSize ss1 + statSize ss2,
+            statKeyBytes = statKeyBytes ss1 + statKeyBytes ss2,
+            statValueBytes = statValueBytes ss1 + statValueBytes ss2,
+            statMaxKVBytes = statMaxKVBytes ss1 `max` statMaxKVBytes ss2
+        }
 
 
 incrementStats :: SStats -> SKey -> SValue -> SStats
@@ -80,5 +88,6 @@ incrementStats stat (SKey (Storable k)) (SValue (Storable v)) =
     SStats { 
         statSize = statSize stat + 1, 
         statKeyBytes = statKeyBytes stat + fromIntegral (BS.length k),
-        statValueBytes = statValueBytes stat + fromIntegral (BS.length v)
+        statValueBytes = statValueBytes stat + fromIntegral (BS.length v),
+        statMaxKVBytes = statMaxKVBytes stat `max` fromIntegral (BS.length v)
     }  

--- a/src/RPKI/Store/Base/Storable.hs
+++ b/src/RPKI/Store/Base/Storable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 
@@ -17,14 +18,17 @@ import Data.Monoid.Generic
 
 import RPKI.Config
 
-newtype Storable = Storable { unStorable :: BS.ByteString }
-    deriving (Show, Eq, Ord, Generic, NFData, Serialise)
+newtype Storable = Storable { unStorable :: BS.ByteString }    
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (NFData, Serialise)
 
 newtype SValue = SValue { unSValue :: Storable }
-    deriving (Show, Eq, Ord, Generic, NFData, Serialise)
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (NFData, Serialise)
 
 newtype SKey = SKey { unSKey :: Storable }
-    deriving (Show, Eq, Ord, Generic, NFData, Serialise)
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (NFData, Serialise)
 
 -- Strictness here is important
 data StorableUnit a e = SObject {-# UNPACK #-} (StorableObject a) | SError e

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -83,7 +83,8 @@ data DBStats = DBStats {
     sequenceStats   :: SStats,
     slurmStats      :: SStats
 } deriving stock (Show, Eq, Generic)
+
 data TotalDBStats = TotalDBStats {
-    dbStats         :: DBStats,
-    total :: SStats    
+    dbStats :: DBStats,
+    total   :: SStats    
 } deriving stock (Show, Eq, Generic)

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -73,7 +73,7 @@ data TopDownContext s = TopDownContext {
         startingRepositoryCount :: Int,
         interruptedByLimit      :: TVar Limited
     }
-    deriving stock (Generic)
+    deriving stock (Generic)    
 
 
 data Limited = CanProceed | FirstToHitLimit | AlreadyReportedLimit
@@ -120,9 +120,8 @@ createVerifiedResources (getRC -> ResourceCertificate certificate) =
 
 
 verifyLimit :: STM Bool -> TVar Limited -> STM Limited
-verifyLimit hitTheLimit limit = do 
-    z <- readTVar limit
-    case z of 
+verifyLimit hitTheLimit limit =
+    readTVar limit >>= \case    
         CanProceed -> do 
             h <- hitTheLimit
             if h then do
@@ -188,7 +187,7 @@ validateTA :: Storage s =>
 validateTA appContext tal worldVersion repositoryProcessing = do    
     r <- runValidatorT taContext $
             timedMetric (Proxy :: Proxy ValidationMetric) $ do 
-                ((taCert, repos, _), elapsed) <- timedMS $ validateTACertificateFromTAL appContext tal worldVersion
+                ((taCert, repos, _), _) <- timedMS $ validateTACertificateFromTAL appContext tal worldVersion
                 -- this will be used as the "now" in all subsequent time and period validations 
                 let now = Now $ versionToMoment worldVersion
                 topDownContext <- newTopDownContext worldVersion 

--- a/src/RPKI/TopDown.hs
+++ b/src/RPKI/TopDown.hs
@@ -785,7 +785,7 @@ markValidatedObjects AppContext { .. } TopDownContext {..} = liftIO $ do
             pure (Set.size vhs, Map.size vmfts)
 
     logInfo_ logger 
-        [i|Marked #{visitedSize} objects as used, #{validMftsSize} manifests as valid, took #{elapsed}ms.|]
+        [i|Marked #{visitedSize} objects as used, #{validMftsSize} manifests as valid for TA #{unTaName taName}, took #{elapsed}ms.|]
 
 
 

--- a/src/RPKI/Util.hs
+++ b/src/RPKI/Util.hs
@@ -19,6 +19,7 @@ import qualified Data.ByteString.Lazy        as LBS
 import qualified Data.ByteString.Short       as BSS
 import qualified Data.ByteString.Base64      as B64
 import           Data.Char
+import qualified Data.List                   as List
 import qualified Data.String.Conversions     as SC
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
@@ -80,11 +81,8 @@ normalizeUri = Text.map (\c -> if isOkForAFile c then c else '_')
 trim :: BS.ByteString -> BS.ByteString
 trim = C.dropWhile isSpace . fst . C.breakEnd (not . isSpace)
 
-trimL :: LBS.ByteString -> LBS.ByteString
-trimL = LC.takeWhile (not . isSpace) . LC.dropWhile isSpace
-
-trimS :: String -> String
-trimS = takeWhile (not . isSpace) . dropWhile isSpace
+trimmed :: Show a => a -> Text
+trimmed = Text.strip . Text.pack . show
 
 removeSpaces :: BS.ByteString -> BS.ByteString
 removeSpaces = C.filter (not . isSpace)

--- a/src/RPKI/Util.hs
+++ b/src/RPKI/Util.hs
@@ -10,10 +10,11 @@ import           Data.Bifunctor
 
 import qualified Crypto.Hash.SHA256          as S256
 import qualified Data.ByteString             as BS
-import qualified Data.ByteString.Lazy        as BSL
+import qualified Data.ByteString.Lazy        as LBS
 import qualified Data.ByteString.Base16      as Hex
 import qualified Data.ByteString.Base16.Lazy as HexLazy
 import qualified Data.ByteString.Char8       as C
+import qualified Data.ByteString.Lazy.Char8  as LC
 import qualified Data.ByteString.Lazy        as LBS
 import qualified Data.ByteString.Short       as BSS
 import qualified Data.ByteString.Base64      as B64
@@ -48,7 +49,7 @@ unhex hexed =
 hex :: BS.ByteString -> BS.ByteString
 hex = Hex.encode    
 
-hexL :: BSL.ByteString -> BSL.ByteString
+hexL :: LBS.ByteString -> LBS.ByteString
 hexL = HexLazy.encode    
 
 class ConvertibleAsSomethigString s1 s2 where
@@ -77,6 +78,9 @@ normalizeUri = Text.map (\c -> if isOkForAFile c then c else '_')
 
 trim :: BS.ByteString -> BS.ByteString
 trim = C.dropWhile isSpace . fst . C.breakEnd (not . isSpace)
+
+trimL :: LBS.ByteString -> LBS.ByteString
+trimL = LC.takeWhile (not . isSpace) . LC.dropWhile isSpace
 
 removeSpaces :: BS.ByteString -> BS.ByteString
 removeSpaces = C.filter (not . isSpace)

--- a/src/RPKI/Util.hs
+++ b/src/RPKI/Util.hs
@@ -22,6 +22,7 @@ import           Data.Char
 import qualified Data.String.Conversions     as SC
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
+import           Data.Text.Encoding          (decodeUtf8)
 import           Data.Word
 import           RPKI.Domain
 import           RPKI.Reporting
@@ -82,6 +83,9 @@ trim = C.dropWhile isSpace . fst . C.breakEnd (not . isSpace)
 trimL :: LBS.ByteString -> LBS.ByteString
 trimL = LC.takeWhile (not . isSpace) . LC.dropWhile isSpace
 
+trimS :: String -> String
+trimS = takeWhile (not . isSpace) . dropWhile isSpace
+
 removeSpaces :: BS.ByteString -> BS.ByteString
 removeSpaces = C.filter (not . isSpace)
 
@@ -139,3 +143,5 @@ decodeBase64 (EncodedBase64 bs) context =
 encodeBase64 :: DecodedBase64 -> EncodedBase64
 encodeBase64 (DecodedBase64 bs) = EncodedBase64 $ B64.encodeBase64' bs
     
+textual :: LBS.ByteString -> Text
+textual = decodeUtf8 . LBS.toStrict

--- a/src/RPKI/Util.hs
+++ b/src/RPKI/Util.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Short       as BSS
 import qualified Data.ByteString.Base64      as B64
 import           Data.Char
 import qualified Data.List                   as List
+import           Data.Foldable (toList)
 import qualified Data.String.Conversions     as SC
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
@@ -143,3 +144,10 @@ encodeBase64 (DecodedBase64 bs) = EncodedBase64 $ B64.encodeBase64' bs
     
 textual :: LBS.ByteString -> Text
 textual = decodeUtf8 . LBS.toStrict
+
+fmtLocations :: Locations -> Text
+fmtLocations = mconcat . 
+               List.intersperse "," . 
+               map (Text.pack . show) . 
+               toList . 
+               unLocations

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -49,7 +49,7 @@ data WorkerParams = RrdpFetchParams {
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (Serialise)
 
-newtype Timeout = Timeout Seconds
+newtype Timebox = Timebox Seconds
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (Serialise)
 
@@ -57,7 +57,7 @@ data WorkerInput = WorkerInput {
         params          :: WorkerParams,
         config          :: Config,
         initialParentId :: ProcessID,
-        workerTimeout    :: Timeout
+        workerTimeout    :: Timebox
     } 
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (Serialise)
@@ -77,7 +77,7 @@ runWorker :: (Serialise r, Show r) =>
             AppLogger 
             -> Config            
             -> WorkerParams                 
-            -> Timeout
+            -> Timebox
             -> [String] 
             -> ValidatorT IO (r, LBS.ByteString)  
 runWorker logger config params timeout extraCli = do  

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -71,8 +71,8 @@ data WorkerParams = RrdpFetchParams {
                 validatorPath :: ValidatorPath, 
                 rrdpRepository :: RrdpRepository,
                 worldVersion :: WorldVersion 
-            }
-        |  CompactionParams { 
+            } | 
+            CompactionParams { 
                 targetLmdbEnv :: FilePath 
             }
     deriving stock (Eq, Ord, Show, Generic)
@@ -190,7 +190,7 @@ executeWork input actualWork =
                 exitWith exitParentDied    
             threadDelay 500_000                
 
-    -- Time bomb. Wait for the certain timeout and then simply exit.
+    -- Time bomb. Wait for the certain timeout and then exit.
     timeoutWait = do
         let Timebox (Seconds s) = input ^. #workerTimeout
         threadDelay $ 1_000_000 * fromIntegral s        

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE OverloadedStrings    #-}
 
-module RPKI.Process where
+module RPKI.Worker where
 
 import           Codec.Serialise
 
@@ -94,7 +94,7 @@ runWorker logger config params timeout extraCli = do
     z <- liftIO $ try $ readProcess worker
     case z of 
         Left (e :: SomeException) -> 
-            -- skip async exceptions
+            -- rethrow async exceptions
             case fromException (toException e) of                
                 Just (SomeAsyncException _) -> throwIO e
                 Nothing -> complain [i|Worker failed with #{fmtEx e}|]              

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -14,7 +14,7 @@ import           Control.Concurrent.STM
 import           Control.Exception
 import           Control.Monad
 
-import           Control.Lens                     ((^.), (%~), (&))
+import           Control.Lens                     ((^.))
 import           Data.Generics.Product.Typed
 
 import           Data.Int                         (Int64)

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,8 +44,8 @@ packages:
 extra-deps: 
   - git: https://github.com/lolepezy/lmdb-high-level.git
     commit: 98630fb39ac34fe209ef03a3d6eb21c9a7a551cb
-  - git: https://github.com/lolepezy/hs-certificate.git
-    commit: f094fe1a81fe57a2ba42ef919af02bbc7f0b6dcb    
+  - git: https://github.com/lolepezy/hs-certificate.git  
+    commit: 6102aaee9d971618309eb8365b0029e6f57f86bb    
     subdirs:
       - x509
       - x509-validation

--- a/test/src/RPKI/Orphans.hs
+++ b/test/src/RPKI/Orphans.hs
@@ -160,8 +160,12 @@ instance Arbitrary a => Arbitrary (X509.Signed a) where
     arbitrary = genericArbitrary
     shrink = genericShrink
     
+instance Arbitrary NullParam where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
 instance Arbitrary SignatureALG where    
-    arbitrary = pure $ SignatureALG HashSHA256 PubKeyALG_RSA
+    arbitrary = SignatureALG HashSHA256 PubKeyALG_RSA <$> arbitrary
 
 instance (Arbitrary a, Ord a) => Arbitrary (NESet.NESet a) where
     arbitrary = genericArbitrary

--- a/test/src/RPKI/Orphans.hs
+++ b/test/src/RPKI/Orphans.hs
@@ -431,6 +431,10 @@ instance Arbitrary InitError where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+instance Arbitrary InternalError where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
 instance Arbitrary SlurmError where
     arbitrary = genericArbitrary
     shrink = genericShrink


### PR DESCRIPTION
Use processes to 
- have some potentially insecure activities restricted by a separate worker process
- avoid heap fragmentation due to usage of mmap 