### PR TITLE
Jobs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -235,6 +235,7 @@ createAppContext cliOptions@CLIOptions{..} logger derivedLogLevel = do
                 & maybeSet (#httpApiConf . #port) httpApiPort
                 & #rtrConfig .~ rtrConfig
                 & maybeSet #cacheLifeTime ((\hours -> Seconds (hours * 60 * 60)) <$> cacheLifetimeHours)
+                & maybeSet #oldVersionsLifetime ((\hours -> Seconds (hours * 60 * 60)) <$> oldVersionsLifeTimeHours)
                 & #lmdbSizeMb .~ lmdbRealSize            
                 & #localExceptions .~ localExceptions    
                 & #logLevel .~ derivedLogLevel                
@@ -452,6 +453,11 @@ data CLIOptions wrapped = CLIOptions {
 
     cacheLifetimeHours :: wrapped ::: Maybe Int64 <?>
         "Lifetime of objects in the local cache, in hours (default is 72 hours)",
+
+    oldVersionsLifeTimeHours :: wrapped ::: Maybe Int64 <?>
+        ("Lifetime of versions in the local cache, in hours (default is 24 hours). " +++ 
+         "Every re-validation creates a new version and associates resulting data " +++ 
+         "(validation results, metrics, VRPs, etc.) with it."),
 
     rrdpRefreshInterval :: wrapped ::: Maybe Int64 <?>
         ("Period of time after which an RRDP repository must be updated, "

--- a/src/RPKI/AppState.hs
+++ b/src/RPKI/AppState.hs
@@ -51,10 +51,8 @@ getWorldVerionIO AppState {..} = readTVarIO world
 
 getOrCreateWorldVerion :: AppState -> IO WorldVersion
 getOrCreateWorldVerion AppState {..} = 
-    join $ atomically $ do 
-        readTVar world >>= \case
-            Nothing -> pure $ newWorldVersion
-            Just wv -> pure $ pure wv 
+    join $ atomically $ 
+        maybe newWorldVersion pure <$> readTVar world
 
 versionToMoment :: WorldVersion -> Instant
 versionToMoment (WorldVersion nanos) = fromNanoseconds nanos

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -183,10 +183,10 @@ defaultConfig = Config {
         port = 9999
     },
     rtrConfig                 = Nothing,
-    cacheCleanupInterval      = Seconds $ 60 * 120,
+    cacheCleanupInterval      = Seconds $ 60 * 60 * 12,
     cacheLifeTime             = Seconds $ 60 * 60 * 72,
-    oldVersionsLifetime       = Seconds $ 60 * 60 * 10,
-    storageCompactionInterval = Seconds $ 60 * 60 * 24,
+    oldVersionsLifetime       = Seconds $ 60 * 60 * 24,
+    storageCompactionInterval = Seconds $ 60 * 60 * 120,
     lmdbSizeMb                = Size $ 32 * 1024,
     localExceptions = [],
     logLevel = defaultsLogLevel,

--- a/src/RPKI/Http/Api.hs
+++ b/src/RPKI/Http/Api.hs
@@ -33,6 +33,7 @@ data API api = API {
         metrics :: api :- "metrics"        :> Get '[JSON] MetricsDto,
                 
         lmdbStats :: api :- "lmdb-stats" :> Get '[JSON] TotalDBStats,
+        jobs :: api :- "jobs" :> Get '[JSON] JobsDto,
 
         publicationsPoints :: api :- "repositories" :> Get '[JSON] PublicationPointDto,
 

--- a/src/RPKI/Http/HttpServer.hs
+++ b/src/RPKI/Http/HttpServer.hs
@@ -66,6 +66,7 @@ httpApi appContext@AppContext {..} = genericServe HttpApi {
         metrics = snd <$> getMetrics appContext,                
         publicationsPoints = getPPs appContext,
         lmdbStats = getStats appContext,
+        jobs = getJobs appContext,
         objectView = getRpkiObject appContext,
         config = pure config
     }
@@ -174,6 +175,12 @@ toVR (Scope scope, issues) = FullVDto {
 
 getStats :: (MonadIO m, Storage s) => AppContext s -> m TotalDBStats
 getStats AppContext {..} = liftIO $ getTotalDbStats =<< readTVarIO database             
+
+getJobs :: (MonadIO m, Storage s) => AppContext s -> m JobsDto
+getJobs AppContext {..} = liftIO $ do 
+    db <- readTVarIO database
+    jobs <- roTx db $ \tx -> allJobs tx db
+    pure JobsDto {..}    
 
 getPPs :: (MonadIO m, Storage s) => AppContext s -> m PublicationPointDto
 getPPs AppContext {..} = liftIO $ do 

--- a/src/RPKI/Http/Types.hs
+++ b/src/RPKI/Http/Types.hs
@@ -82,6 +82,12 @@ data MetricsDto = MetricsDto {
 
 data PublicationPointDto = PublicationPointDto {
         rrdp :: [(RrdpURL, RrdpRepository)]
+        -- TODO Add rsync tree here
+    } 
+    deriving stock (Eq, Show, Generic)
+
+newtype JobsDto = JobsDto {
+        jobs :: [(Text, Instant)]
     } 
     deriving stock (Eq, Show, Generic)
             
@@ -98,6 +104,7 @@ instance MimeRender ManualCVS RawCVS where
 
 instance ToJSON RObject
 instance ToJSON VrpDto     
+instance ToJSON JobsDto     
 
 instance ToJSON a =>  ToJSON (ValidationsDto a)
 

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -456,6 +456,10 @@ setJobTime :: (MonadIO m, Storage s) =>
             Tx s 'RW -> DB s -> Text -> Instant -> m ()
 setJobTime tx DB { jobStore = JobStore s } job t = liftIO $ M.put tx s job t
 
+allJobs :: (MonadIO m, Storage s) => 
+            Tx s mode -> DB s -> m [(Text, Instant)]
+allJobs tx DB { jobStore = JobStore s } = liftIO $ M.all tx s
+
 -- More complicated operations
 
 data CleanUpResult = CleanUpResult {

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -24,6 +24,8 @@ import           Data.Int                         (Int64)
 import           Data.Hourglass
 import           Data.String.Interpolate.IsString
 
+import           GHC.Generics
+
 import           System.Exit
 import           System.Directory
 import           System.FilePath                  ((</>))
@@ -47,6 +49,7 @@ import           RPKI.TAL
 import           RPKI.Time
 
 import           RPKI.Store.AppStorage
+import Data.Text (Text)
 
 
 runWorkflow :: (Storage s, MaintainableStorage s) => 
@@ -79,7 +82,6 @@ runWorkflow appContext@AppContext {..} tals = do
             generatePeriodicTask 10_000_000 cacheCleanupInterval cacheGC,
             generatePeriodicTask 30_000_000 cacheCleanupInterval cleanOldVersions,
             generatePeriodicTask (12 * 60 * 60 * 1_000_000) storageCompactionInterval compact,
-            -- generatePeriodicTask (1 * 1_000_000) storageCompactionInterval compact,
             rtrServer   
         ]
     where
@@ -284,3 +286,9 @@ periodically (Seconds interval) action = go
             Done   -> pure ()        
 
 data NextStep = Repeat | Done
+
+
+gcJob, compactionJob, cleanOldVersionsJob :: Text
+gcJob = "gcJob"
+compactionJob = "compactionJob"
+cleanOldVersionsJob = "cleanOldVersionsJob"

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -18,14 +18,12 @@ import           Control.Lens                     ((^.))
 import           Data.Generics.Product.Typed
 
 import           Data.Foldable (for_)
+import           Data.Maybe (mapMaybe)
 
 import           Data.Int                         (Int64)
 
 import           Data.Hourglass
 import           Data.String.Interpolate.IsString
-
-import           GHC.Generics
-
 import           System.Exit
 import           System.Directory
 import           System.FilePath                  ((</>))
@@ -49,10 +47,9 @@ import           RPKI.TAL
 import           RPKI.Time
 
 import           RPKI.Store.AppStorage
-import Data.Text (Text)
 
 
-runWorkflow :: (Storage s, MaintainableStorage s) => 
+runWorkflow :: (Storage s, MaintainableStorage s) =>
                 AppContext s -> [TAL] -> IO ()
 runWorkflow appContext@AppContext {..} tals = do
 
@@ -60,7 +57,7 @@ runWorkflow appContext@AppContext {..} tals = do
     -- operations and such should not run at the same time with validation 
     -- (not only for consistency reasons, but we also want to avoid locking 
     -- the DB for long time by a cleanup process).
-    globalQueue <- newCQueueIO 10    
+    globalQueue <- newCQueueIO 10
 
     -- Fill in the current state if it's not too old.
     -- It is useful in case of restarts.        
@@ -73,107 +70,157 @@ runWorkflow appContext@AppContext {..} tals = do
     -- Initialise prometheus metrics here
     prometheusMetrics <- createPrometheusMetrics config
 
-    -- Run threads that periodicallly generate tasks and one thread that 
-    -- executes the tasks. Tasks are put into the queue after having been 
-    -- generated. `taskExecutor` picks them up from the queue and executes.
-    mapConcurrently_ (\f -> f globalQueue) [ 
-            taskExecutor,
-            generateRevalidationTask prometheusMetrics, 
-            generatePeriodicTask 10_000_000 cacheCleanupInterval cacheGC,
-            generatePeriodicTask 30_000_000 cacheCleanupInterval cleanOldVersions,
-            generatePeriodicTask (12 * 60 * 60 * 1_000_000) storageCompactionInterval compact,
-            rtrServer   
+    -- This is a flag to determine if datbase compaction may be required at all.
+    deletedSomeData <- newTVarIO False
+
+    -- Run threads that 
+    --  - generate re-validation jobs        
+    --  - periodicallly generate jobs and put them into 
+    --    the queue based on the last execution time
+    --  - take jobs from the queue and execute them
+    -- 
+    mapConcurrently_ (\f -> f globalQueue) [
+            jobExecutor,
+            pollJobs deletedSomeData,
+            generateRevalidationJob prometheusMetrics,            
+            rtrServer
         ]
     where
-        storageCompactionInterval = config ^. #storageCompactionInterval
-        cacheCleanupInterval = config ^. #cacheCleanupInterval
-        oldVersionsLifetime  = config ^. #oldVersionsLifetime
-        cacheLifeTime        = config ^. #cacheLifeTime
-        revalidationInterval = config ^. typed @ValidationConfig . #revalidationInterval
-        rtrConfig            = config ^. #rtrConfig
-
         -- periodically update world version and generate command 
         -- to re-validate all TAs
-        generateRevalidationTask prometheusMetrics globalQueue = do            
-            periodically revalidationInterval (do                                 
-                    writeQ globalQueue (validateAllTAs prometheusMetrics)                    
-                    pure Repeat)
+        generateRevalidationJob prometheusMetrics globalQueue =
+            periodically (config ^. typed @ValidationConfig . #revalidationInterval) 
+                    (do
+                        writeQ globalQueue (validateAllTAs prometheusMetrics)
+                        pure Repeat)
                 `finally`
-                atomically (closeCQueue globalQueue)
+                    atomically (closeCQueue globalQueue)        
 
-        taskExecutor globalQueue = go 
+        -- 60 seconds resolution is good enough for all the practical purposes here.
+        pollJobs deletedSomeData globalQueue = periodically 60 $ do
+            
+            let availableJobs = [
+                        ("gcJob",               config ^. #cacheCleanupInterval, cacheGC deletedSomeData),
+                        ("cleanOldVersionsJob", config ^. #storageCompactionInterval, compact deletedSomeData),
+                        ("compactionJob",       config ^. #cacheCleanupInterval, cleanOldVersions deletedSomeData)
+                    ]
+
+            Now now <- thisInstant
+            jobs <- do
+                db <- readTVarIO database
+                roTx db $ \tx -> allJobs tx db
+
+            let toBeExecuted = flip mapMaybe availableJobs $
+                        \(job, interval, action) ->
+                            case filter ((==job) . fst) jobs of
+                                [] -> Just (job, action)
+                                [(_, lastExecuted)]
+                                    | lastExecuted > now ||
+                                        closeEnoughMoments lastExecuted now interval
+                                        -> Nothing
+                                    | otherwise
+                                        -> Just (job, action)
+                                _ -> Nothing
+
+            unless (null toBeExecuted) $
+                logDebug_ logger [i|Jobs to be executed: #{map fst toBeExecuted}.|]
+            for_ toBeExecuted $ \(jobName, jobF) -> do
+                closed <- atomically $ isClosedCQueue globalQueue
+                unless closed $
+                    writeQ globalQueue $ \worldVersion' -> do
+                        logDebug_ logger [i|Executing job #{jobName}.|]
+                        jobF worldVersion' `finally` (do
+                            Now endTime <- thisInstant
+                            -- re-read `db` since it could have been changed by the time the
+                            -- job is finished (after compaction, for example)                            
+                            db <- readTVarIO database
+                            rwTx db $ \tx -> setJobTime tx db jobName endTime)
+
+            closed <- atomically $ isClosedCQueue globalQueue
+            pure $ if closed then Done else Repeat
+
+        jobExecutor globalQueue = go
           where
-            go = do 
+            go = do
                 z <- atomically (readCQueue globalQueue)
-                for_ z $ \task -> updateWorldVersion >>= task >> go
-        
+                for_ z $ \job -> updateWorldVersion >>= job >> go
+
         validateAllTAs prometheusMetrics worldVersion = do
             logInfo_ logger [i|Validating all TAs, world version #{worldVersion} |]
-            database' <- readTVarIO database 
+            database' <- readTVarIO database
             executeOrDie
                 (processTALs database' `finally` cleanupAfterValidation)
-                (\(vrps, slurmedVrps) elapsed ->                    
+                (\(vrps, slurmedVrps) elapsed ->
                     logInfoM logger $
-                        [i|Validated all TAs, got #{estimateVrpCount vrps} VRPs (probably not unique), |] <> 
+                        [i|Validated all TAs, got #{estimateVrpCount vrps} VRPs (probably not unique), |] <>
                         [i|#{estimateVrpCount slurmedVrps} SLURM-ed VRPs, took #{elapsed}ms|])
-            where 
-                cleanupAfterValidation = do 
+            where
+                cleanupAfterValidation = do
                     let tmpDir = config ^. #tmpDirectory
-                    logDebugM logger [i|Cleaning up temporary directory #{tmpDir}.|]                    
+                    logDebugM logger [i|Cleaning up temporary directory #{tmpDir}.|]
                     listDirectory tmpDir >>= mapM_ (removePathForcibly . (tmpDir </>))
-                    
-                processTALs database' = do
-                    TopDownResult {..} <- addUniqueVRPCount . mconcat <$> 
-                                validateMutlipleTAs appContext worldVersion tals                        
 
-                    updatePrometheus (topDownValidations ^. typed) prometheusMetrics worldVersion                                   
+                processTALs database' = do
+                    TopDownResult {..} <- addUniqueVRPCount . mconcat <$>
+                                validateMutlipleTAs appContext worldVersion tals
+
+                    updatePrometheus (topDownValidations ^. typed) prometheusMetrics worldVersion
 
                     -- Apply SLURM if it is set in the appState
-                    (slurmValidations, maybeSlurm) <- 
+                    (slurmValidations, maybeSlurm) <-
                         case appState ^. #readSlurm of
                             Nothing       -> pure (mempty, Nothing)
-                            Just readFunc -> do 
+                            Just readFunc -> do
                                 logInfoM logger [i|Re-reading and re-validating SLURM files.|]
                                 (z, vs) <- runValidatorT (newScopes "read-slurm") readFunc
-                                case z of 
-                                    Left e -> do 
+                                case z of
+                                    Left e -> do
                                         logErrorM logger [i|Failed to read apply SLURM files: #{e}|]
                                         pure (vs, Nothing)
-                                    Right slurm -> 
+                                    Right slurm ->
                                         pure (vs, Just slurm)
 
                     -- Save all the results into LMDB
                     let updatedValidation = slurmValidations <> topDownValidations ^. typed
                     rwTx database' $ \tx -> do
                         putValidations tx database' worldVersion (updatedValidation ^. typed)
-                        putMetrics tx database' worldVersion (topDownValidations ^. typed)                        
+                        putMetrics tx database' worldVersion (topDownValidations ^. typed)
                         putVrps tx database' vrps worldVersion
                         for_ maybeSlurm $ putSlurm tx database' worldVersion
                         completeWorldVersion tx database' worldVersion
-                        slurmedVrps <- atomically $ do 
+                        slurmedVrps <- atomically $ do
                             setCurrentVersion appState worldVersion
                             completeVersion appState worldVersion vrps maybeSlurm
                         pure (vrps, slurmedVrps)
 
-        cacheGC worldVersion = do            
-            database' <- readTVarIO database 
-            executeOrDie 
-                (cleanObjectCache database' $ versionIsOld (versionToMoment worldVersion) cacheLifeTime)
-                (\CleanUpResult {..} elapsed -> 
-                    logInfo_ logger $ [i|Cleanup: deleted #{deletedObjects} objects, kept #{keptObjects}, |] <> 
-                                      [i|deleted #{deletedURLs} dangling URLs, took #{elapsed}ms|])
+        cacheGC deletedSomeData worldVersion = do
+            database' <- readTVarIO database
+            executeOrDie
+                (cleanObjectCache database' $ versionIsOld (versionToMoment worldVersion) (config ^. #cacheLifeTime))
+                (\CleanUpResult {..} elapsed -> do 
+                    when (deletedObjects > 0) $ 
+                        atomically $ writeTVar deletedSomeData True
+                    logInfo_ logger $ [i|Cleanup: deleted #{deletedObjects} objects, kept #{keptObjects}, |] <>
+                                      [i|deleted #{deletedURLs} dangling URLs, took #{elapsed}ms.|])
 
-        cleanOldVersions worldVersion = do
+        cleanOldVersions deletedSomeData worldVersion = do
             let now = versionToMoment worldVersion
-            database' <- readTVarIO database 
-            executeOrDie 
-                (deleteOldVersions database' $ versionIsOld now oldVersionsLifetime)
-                (\deleted elapsed -> 
-                    logInfo_ logger [i|Done with deleting older versions, deleted #{deleted} versions, took #{elapsed}ms|])
+            database' <- readTVarIO database
+            executeOrDie
+                (deleteOldVersions database' $ versionIsOld now (config ^. #oldVersionsLifetime))
+                (\deleted elapsed -> do 
+                    when (deleted > 0) $ 
+                        atomically $ writeTVar deletedSomeData True
+                    logInfo_ logger [i|Done with deleting older versions, deleted #{deleted} versions, took #{elapsed}ms.|])
 
-        compact worldVersion = do
-            (_, elapsed) <- timedMS $ runMaintenance appContext 
-            logInfo_ logger [i|Done with compacting the storage, version #{worldVersion}, took #{elapsed}ms|]
+        compact deletedSomeData worldVersion = do
+            -- Some heuristics first to see if it's obvisouly too early to run compaction 
+            deletedSomething <- readTVarIO deletedSomeData
+            if deletedSomething then do 
+                (_, elapsed) <- timedMS $ runMaintenance appContext
+                logInfo_ logger [i|Done with compacting the storage, version #{worldVersion}, took #{elapsed}ms.|]
+            else 
+                logDebug_ logger [i|Nothing has been deleted from the storage, will not run compaction.|]
 
         executeOrDie :: IO a -> (a -> Int64 -> IO ()) -> IO ()
         executeOrDie f onRight =
@@ -181,85 +228,85 @@ runWorkflow appContext@AppContext {..} tals = do
                     Handler $ \(AppException seriousProblem) ->
                         die [i|Something really bad happened #{seriousProblem}, exiting.|],
                     Handler $ \(_ :: AsyncCancelled) ->
-                        die [i|Interrupted with Ctrl-C, exiting.|],                        
+                        die [i|Interrupted with Ctrl-C, exiting.|],
                     Handler $ \(weirdShit :: SomeException) ->
                         logError_ logger [i|Something weird happened #{weirdShit}, exiting.|]
-                ] 
+                ]
             where
-                exec = do 
+                exec = do
                     (r, elapsed) <- timedMS f
                     onRight r elapsed
 
-        initRtrIfNeeded = 
-            case rtrConfig of 
-                Nothing -> do 
+        initRtrIfNeeded =
+            case config ^. #rtrConfig of
+                Nothing -> do
                     pure $ \_ -> pure ()
-                Just rtrConfig' -> 
+                Just rtrConfig' ->
                     pure $ \_ -> runRtrServer appContext rtrConfig'
 
 
         -- Write an action to the global queue with given interval.
-        generatePeriodicTask delay interval action globalQueue = do
-            threadDelay delay
-            periodically interval $ do                 
-                closed <- atomically $ isClosedCQueue globalQueue
-                unless closed $ writeQ globalQueue action
-                pure $ if closed 
-                        then Done
-                        else Repeat
+        -- generatePeriodicJob delay interval action globalQueue = do
+        --     threadDelay delay
+        --     periodically interval $ do                 
+        --         closed <- atomically $ isClosedCQueue globalQueue
+        --         unless closed $ writeQ globalQueue action
+        --         pure $ if closed 
+        --                 then Done
+        --                 else Repeat
 
-        updateWorldVersion = do 
-            newVersion <- newWorldVersion      
-            existing <- getWorldVerionIO appState          
+        updateWorldVersion = do
+            newVersion <- newWorldVersion
+            existing <- getWorldVerionIO appState
             logDebug_ logger $ case existing of
-                Nothing -> 
-                    [i|Generated first world version #{newVersion}.|]                
+                Nothing ->
+                    [i|Generated first world version #{newVersion}.|]
                 Just oldWorldVersion ->
                     [i|Generated new world version, #{oldWorldVersion} ==> #{newVersion}.|]
             pure newVersion
 
 
-        writeQ globalQueue z = do 
+        writeQ globalQueue z = do
             isFull <- atomically $ ifFullCQueue globalQueue
             when isFull $ logInfoM logger $
-                                [i|Task queue is full. Normally that means that revalidation interval |] <>
+                                [i|Job queue is full. Normally that means that revalidation interval |] <>
                                 [i|is too short for the time validation takes. It is recommended to restart |] <>
-                                [i|with a higher re-validation interval value.|]                                    
-            atomically $ writeCQueue globalQueue z                        
+                                [i|with a higher re-validation interval value.|]
+            atomically $ writeCQueue globalQueue z
 
 
 -- | Load the state corresponding to the last completed version.
 -- 
 loadStoredAppState :: Storage s => AppContext s -> IO (Maybe WorldVersion)
-loadStoredAppState AppContext {..} = do     
-    Now now' <- thisInstant    
+loadStoredAppState AppContext {..} = do
+    Now now' <- thisInstant
     let revalidationInterval = config ^. typed @ValidationConfig . #revalidationInterval
-    database' <- readTVarIO database 
-    roTx database' $ \tx -> 
-        getLastCompletedVersion database' tx >>= \case 
+    database' <- readTVarIO database
+    roTx database' $ \tx ->
+        getLastCompletedVersion database' tx >>= \case
             Nothing          -> pure Nothing
 
-            Just lastVersion             
+            Just lastVersion
                 | versionIsOld now' revalidationInterval lastVersion -> do
                     logInfo_ logger [i|Last cached version #{lastVersion} is too old to be used, will re-run validation.|]
                     pure Nothing
 
-                | otherwise -> do                     
-                    (vrps, elapsed) <- timedMS $ do             
+                | otherwise -> do
+                    (vrps, elapsed) <- timedMS $ do
                         -- TODO It takes 350-400ms, which is pretty strange, profile it.           
                         !vrps  <- getVrps tx database' lastVersion
                         !slurm <- slurmForVersion tx database' lastVersion
                         --
-                        for_ vrps $ \vrps' -> void $ 
-                                atomically $ do 
+                        for_ vrps $ \vrps' -> void $
+                                atomically $ do
                                     setCurrentVersion appState lastVersion
                                     completeVersion appState lastVersion vrps' slurm
                         pure vrps
-                    for_ vrps $ \v -> 
-                        logInfo_ logger $ [i|Last cached version #{lastVersion} used to initialise |] <> 
+                    for_ vrps $ \v ->
+                        logInfo_ logger $ [i|Last cached version #{lastVersion} used to initialise |] <>
                                         [i|current state (#{estimateVrpCount v} VRPs), took #{elapsed}ms.|]
-                    pure $ Just lastVersion             
-                
+                    pure $ Just lastVersion
+
 
 -- 
 versionIsOld :: Instant -> Seconds -> WorldVersion -> Bool
@@ -270,25 +317,23 @@ versionIsOld now period (WorldVersion nanos) =
 
 -- | Execute an IO action every N seconds
 periodically :: Seconds -> IO NextStep -> IO ()
-periodically (Seconds interval) action = go 
+periodically interval action = go
   where
-    go = do 
-        Now start <- thisInstant        
+    go = do
+        Now start <- thisInstant
         nextStep <- action
         Now end <- thisInstant
-        let executionTimeNs = toNanoseconds end - toNanoseconds start
-        when (executionTimeNs < nanosPerSecond * interval) $ do        
-            let timeToWaitNs = nanosPerSecond * interval - executionTimeNs                        
-            when (timeToWaitNs > 0) $ 
-                threadDelay $ fromIntegral timeToWaitNs `div` 1000         
-        case nextStep of 
-            Repeat -> go 
-            Done   -> pure ()        
+        delayFromTo start end interval
+        case nextStep of
+            Repeat -> go
+            Done   -> pure ()
 
 data NextStep = Repeat | Done
 
-
-gcJob, compactionJob, cleanOldVersionsJob :: Text
-gcJob = "gcJob"
-compactionJob = "compactionJob"
-cleanOldVersionsJob = "cleanOldVersionsJob"
+delayFromTo :: Instant -> Instant -> Seconds -> IO ()
+delayFromTo start end (Seconds interval) = do
+    let executionTimeNs = toNanoseconds end - toNanoseconds start
+    when (executionTimeNs < nanosPerSecond * interval) $ do
+        let timeToWaitNs = nanosPerSecond * interval - executionTimeNs
+        when (timeToWaitNs > 0) $
+            threadDelay $ fromIntegral timeToWaitNs `div` 1000           


### PR DESCRIPTION
This is to have persisted times for job runs to avoid job starvation if the application is restarted too often. Jobs are now scheduled based on when they run the last time (if ever).