### PR TITLE
Experiment to reduce IO writes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ executeMainProcess cliOptions = do
     withLogConfig cliOptions $ \logConfig -> do
         -- This one modifies system metrics in AppState
         -- if appState is actually initialised
-        let bumpSysMetric = \sm -> do 
+        let bumpSysMetric sm = do 
                 z <- readTVarIO appStateHolder
                 for_ z $ mergeSystemMetrics sm
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -442,6 +442,8 @@ executeWorker input appContext =
                 CompactionResult <$> copyLmdbEnvironment appContext targetLmdbEnv
             ValidationParams {..} -> exec resultHandler $
                 uncurry ValidationResult <$> runValidation appContext worldVersion tals
+            CacheCleanupParams {..} -> exec resultHandler $
+                CacheCleanupResult <$> runCacheCleanup appContext worldVersion
   where
     exec resultHandler f = resultHandler =<< execWithTiming f
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -160,8 +160,8 @@ runValidatorServer appContext@AppContext {..} = do
 
     logInfo logger [i|Successfully loaded #{length talNames} TALs: #{map snd talNames}|]
 
-    database' <- readTVarIO database
-    rwTx database' $ \tx -> saveValidations tx database' worldVersion (vs ^. typed)
+    db <- readTVarIO database
+    rwTx db $ \tx -> saveValidations tx db worldVersion (vs ^. typed)
     case tals of
         Left e -> do
             logError logger [i|Error reading some of the TALs, e = #{e}.|]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -161,7 +161,7 @@ runValidatorServer appContext@AppContext {..} = do
     logInfo logger [i|Successfully loaded #{length talNames} TALs: #{map snd talNames}|]
 
     database' <- readTVarIO database
-    rwTx database' $ \tx -> putValidations tx database' worldVersion (vs ^. typed)
+    rwTx database' $ \tx -> saveValidations tx database' worldVersion (vs ^. typed)
     case tals of
         Left e -> do
             logError logger [i|Error reading some of the TALs, e = #{e}.|]

--- a/mem/MemLeaker.hs
+++ b/mem/MemLeaker.hs
@@ -61,9 +61,9 @@ main = do
             
         (Right appContext, _) -> do             
 
-            database' <- readTVarIO (appContext ^. #database)
+            db <- readTVarIO (appContext ^. #database)
             worldVersion <- updateWorldVersion (appContext ^. #appState)
-            storedPubPoints   <- roTx database' $ \tx -> getPublicationPoints tx (repositoryStore database')
+            storedPubPoints   <- roTx db $ \tx -> getPublicationPoints tx (repositoryStore db)
 
             forConcurrently_ sources $ \(repository, _) -> do
                     runValidatorT (newScopes "download-rrdp") 
@@ -86,7 +86,7 @@ main = do
 
                 let TopDownResult {..} = mconcat results
                 logInfo logger [i|Validated GC, #{Set.size vrps} VRPs, took #{elapsed}ms|]
-                (cleanup, elapsed2) <- timedMS $ cleanObjectCache database' $ versionIsOld now cacheLifeTime
+                (cleanup, elapsed2) <- timedMS $ cleanObjectCache db $ versionIsOld now cacheLifeTime
                 logInfo logger [i|Done with cache GC, #{cleanup}, took #{elapsed2}ms|]
 
     where

--- a/src/RPKI/AppMonad.hs
+++ b/src/RPKI/AppMonad.hs
@@ -83,14 +83,7 @@ fromTry :: Exception exc =>
             (exc -> AppError) -> 
             IO r -> 
             ValidatorT IO r
-fromTry mapErr t =
-    liftIO t `catch` recoverOrRethrow        
-    where
-        recoverOrRethrow e = 
-            case fromException (toException e) of
-                Just (SomeAsyncException _) -> throwIO e
-                Nothing                     -> appError $ mapErr e
-
+fromTry mapErr t = fromTryM mapErr (liftIO t)
 
 fromTryM :: Exception exc =>              
             (exc -> AppError) -> 

--- a/src/RPKI/AppTypes.hs
+++ b/src/RPKI/AppTypes.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module RPKI.AppTypes where
     
@@ -21,7 +22,7 @@ newtype WorldVersion = WorldVersion Int64
 
 -- Keep it just text for now since we don't
 -- know what may be needed there in the future.
-data VersionState = VersionState Text
+data VersionKind = VersionKind Text
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (TheBinary)
 
@@ -36,3 +37,8 @@ newtype MaxMemory = MaxMemory Int
 
 instance Show MaxMemory where 
     show (MaxMemory m) = show (m `div` (1024*1024)) <> "mb"
+
+
+validationKind, generalKind :: VersionKind
+validationKind = VersionKind "validation"
+generalKind = VersionKind "general"

--- a/src/RPKI/AppTypes.hs
+++ b/src/RPKI/AppTypes.hs
@@ -27,9 +27,12 @@ data VersionState = VersionState Text
 
 
 -- TODO Probably move it to some other module
-newtype MaxMemory = MaxMemory { unMaxMemory :: Int }
-    deriving stock (Show, Eq, Ord, Generic)
+newtype MaxMemory = MaxMemory Int
+    deriving stock (Eq, Ord, Generic)
     deriving anyclass (TheBinary)    
     deriving newtype (Num, Bounded)
     deriving Semigroup via Max MaxMemory
     deriving Monoid via Max MaxMemory    
+
+instance Show MaxMemory where 
+    show (MaxMemory m) = show (m `div` (1024*1024)) <> "mb"

--- a/src/RPKI/Config.hs
+++ b/src/RPKI/Config.hs
@@ -141,7 +141,8 @@ data RtrConfig = RtrConfig {
 data SystemConfig = SystemConfig {
         rsyncWorkerMemoryMb      :: Int,
         rrdpWorkerMemoryMb       :: Int,
-        validationWorkerMemoryMb :: Int
+        validationWorkerMemoryMb :: Int,
+        cleanupWorkerMemoryMb    :: Int
     } 
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (TheBinary)
@@ -203,8 +204,9 @@ defaultConfig = Config {
     },    
     systemConfig = SystemConfig {
         rsyncWorkerMemoryMb      = 1024,
-        rrdpWorkerMemoryMb       = 1024,
-        validationWorkerMemoryMb = 2048
+        rrdpWorkerMemoryMb       = 1024,        
+        validationWorkerMemoryMb = 2048,
+        cleanupWorkerMemoryMb    = 512
     },
     rtrConfig                 = Nothing,
     cacheCleanupInterval      = Seconds $ 60 * 60 * 12,

--- a/src/RPKI/Domain.hs
+++ b/src/RPKI/Domain.hs
@@ -405,7 +405,7 @@ instance WithHash RpkiObject where
     getHash (BgpRO c) = getHash c
 
 data Located a = Located { 
-        locations :: Locations,
+        locations :: Locations,        
         payload   :: a
     }
     deriving stock (Show, Eq, Generic)

--- a/src/RPKI/Http/HttpServer.hs
+++ b/src/RPKI/Http/HttpServer.hs
@@ -282,9 +282,9 @@ getRpkiObject AppContext {..} uri hash =
                     throwError $ err400 { errBody = "'uri' is not a valid object URL." }
 
                 Right rpkiUrl -> liftIO $ do
-                    DB {..} <- readTVarIO database
-                    roTx objectStore $ \tx ->
-                        (locatedDto <$>) <$> getByUri tx objectStore rpkiUrl
+                    db <- readTVarIO database
+                    roTx db $ \tx ->
+                        (locatedDto <$>) <$> getByUri tx db rpkiUrl
 
         (Nothing, Just hash') ->
             case parseHash hash' of

--- a/src/RPKI/Http/HttpServer.hs
+++ b/src/RPKI/Http/HttpServer.hs
@@ -241,8 +241,8 @@ getAllSlurms :: (MonadIO m, Storage s, MonadError ServerError m) =>
 getAllSlurms AppContext {..} = do
     db <- liftIO $ readTVarIO database
     liftIO $ roTx db $ \tx -> do
-        versions <- List.sortOn Down <$> allVersions tx db
-        slurms   <- mapM (\(wv, _) -> (wv, ) <$> slurmForVersion tx db wv) versions        
+        versions <- List.sortOn Down <$> validationVersions tx db
+        slurms   <- mapM (\wv -> (wv, ) <$> slurmForVersion tx db wv) versions        
         pure [ (w, s) | (w, Just s) <- slurms ]
 
 

--- a/src/RPKI/Http/Types.hs
+++ b/src/RPKI/Http/Types.hs
@@ -25,6 +25,7 @@ import           Data.Proxy
 import           GHC.Generics                (Generic)
 import qualified Data.Vector                 as V
 import qualified Data.List.NonEmpty          as NonEmpty
+import           Data.Map.Strict             (Map)
 import qualified Data.Map.Strict             as Map
 
 import           Data.Map.Monoidal.Strict (MonoidalMap)
@@ -217,7 +218,7 @@ data RoaPrefixDto = RoaPrefixDto {
 
 
 data GbrDto = GbrDto {
-        vcard :: Map.Map Text Text
+        vcard :: Map Text Text
     }  
     deriving stock (Eq, Show, Generic)
 

--- a/src/RPKI/Orphans/Json.hs
+++ b/src/RPKI/Orphans/Json.hs
@@ -408,7 +408,7 @@ instance ToJSON SystemConfig
 instance ToJSON RrdpConf
 instance ToJSON RsyncConf    
 
-instance ToJSON VersionState
+instance ToJSON VersionKind
 instance ToJSON VIssue
 instance ToJSON VWarning
 instance ToJSON AppError

--- a/src/RPKI/Orphans/Swagger.hs
+++ b/src/RPKI/Orphans/Swagger.hs
@@ -52,7 +52,7 @@ instance ToSchema URI where
      declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Text)
 
 instance ToSchema WorldVersion     
-instance ToSchema VersionState
+instance ToSchema VersionKind
 instance ToSchema Instant where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Text)
 instance ToSchema DateTime     

--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -68,15 +68,16 @@ runRrdpFetchWorker AppContext {..} worldVersion repository = do
 
     scopes <- askScopes
 
-    WorkerResult {..} <- runWorker
+    wr@WorkerResult {..} <- runWorker
                             logger
                             config
                             workerId 
                             (RrdpFetchParams scopes repository worldVersion)                        
                             (Timebox $ config ^. typed @RrdpConf . #rrdpTimeout)
                             arguments  
-    
+        
     let RrdpFetchResult z = payload
+    logWorkerDone logger workerId wr
     pushSystem logger $ cpuMemMetric "fetch" cpuTime maxMemory
     embedValidatorT $ pure z
 

--- a/src/RPKI/Rsync.hs
+++ b/src/RPKI/Rsync.hs
@@ -102,14 +102,15 @@ runRsyncFetchWorker AppContext {..} worldVersion rsyncRepo = do
                 rtsMaxMemory $ rtsMemValue (config ^. typed @SystemConfig . #rsyncWorkerMemoryMb) ]
 
     vp <- askScopes
-    WorkerResult {..} <- runWorker 
-                            logger
-                            config
-                            workerId 
-                            (RsyncFetchParams vp rsyncRepo worldVersion)                        
-                            (Timebox $ config ^. typed @RsyncConf . #rsyncTimeout)
-                            arguments                        
-    let RsyncFetchResult z = payload    
+    wr@WorkerResult {..} <- runWorker 
+                                logger
+                                config
+                                workerId 
+                                (RsyncFetchParams vp rsyncRepo worldVersion)                        
+                                (Timebox $ config ^. typed @RsyncConf . #rsyncTimeout)
+                                arguments                        
+    let RsyncFetchResult z = payload        
+    logWorkerDone logger workerId wr
     pushSystem logger $ cpuMemMetric "fetch" cpuTime maxMemory
     embedValidatorT $ pure z
     

--- a/src/RPKI/Store/AppLmdbStorage.hs
+++ b/src/RPKI/Store/AppLmdbStorage.hs
@@ -20,6 +20,7 @@ import           Data.Hourglass
 
 import           RPKI.AppContext
 import           RPKI.AppMonad
+import           RPKI.Config
 import           RPKI.Logging
 import           RPKI.Worker
 import           RPKI.Reporting
@@ -29,9 +30,10 @@ import qualified RPKI.Store.Database              as DB
 import           RPKI.Store.MakeLmdb
 import           RPKI.Store.Base.Storable
 import           RPKI.Time
+import           RPKI.Metrics.System
 import           RPKI.Util
 
-import           RPKI.Config
+
 import           System.Directory
 import           System.FilePath                  ((</>))
 import           System.Posix.Files
@@ -293,8 +295,8 @@ runCopyWorker AppContext {..} dbtats targetLmdbPath = do
             let message = [i|Failed to run compaction worker: #{e}, validations: #{vs}.|]
             logError logger message            
             throwIO $ AppException $ InternalE $ InternalError message
-        Right WorkerResult { payload = CompactionResult _ } -> do
-            pure ()            
+        Right WorkerResult { payload = CompactionResult _, .. } -> do
+            pushSystem logger $ cpuMemMetric "compaction" cpuTime maxMemory                     
             
 -- 
 cleanupReaders :: AppContext LmdbStorage -> IO Int

--- a/src/RPKI/Store/AppLmdbStorage.hs
+++ b/src/RPKI/Store/AppLmdbStorage.hs
@@ -295,7 +295,8 @@ runCopyWorker AppContext {..} dbtats targetLmdbPath = do
             let message = [i|Failed to run compaction worker: #{e}, validations: #{vs}.|]
             logError logger message            
             throwIO $ AppException $ InternalE $ InternalError message
-        Right WorkerResult { payload = CompactionResult _, .. } -> do
+        Right wr@WorkerResult { payload = CompactionResult _, .. } -> do
+            logWorkerDone logger workerId wr
             pushSystem logger $ cpuMemMetric "compaction" cpuTime maxMemory                     
             
 -- 

--- a/src/RPKI/Store/Base/Storable.hs
+++ b/src/RPKI/Store/Base/Storable.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString as BS
 
 import Control.DeepSeq
 import Codec.Compression.LZ4
+
 import GHC.Generics
 
 import Data.Maybe (fromMaybe)
@@ -83,7 +84,7 @@ data SStats = SStats {
         statMaxValueBytes :: Size
     } 
     deriving stock (Show, Eq, Generic)    
-    deriving Monoid    via GenericMonoid SStats
+    deriving Monoid via GenericMonoid SStats
 
 instance Semigroup SStats where
     ss1 <> ss2 = 

--- a/src/RPKI/Store/Base/Storage.hs
+++ b/src/RPKI/Store/Base/Storage.hs
@@ -50,3 +50,5 @@ rwTx = readWriteTx . storage
 storageError :: SomeException -> AppError
 storageError = StorageE . StorageError . fmtEx    
 
+class WithTx s => CanErase s a where
+    erase :: Tx s 'RW -> a -> IO ()

--- a/src/RPKI/Store/Base/Storage.hs
+++ b/src/RPKI/Store/Base/Storage.hs
@@ -42,10 +42,10 @@ instance Storage s => WithStorage s s where
     storage = id
 
 roTx :: WithStorage s ws => ws -> (Tx s 'RO -> IO a) -> IO a
-roTx s = readOnlyTx (storage s)
+roTx = readOnlyTx . storage
 
 rwTx :: WithStorage s ws => ws -> (Tx s 'RW -> IO a) -> IO a
-rwTx s = readWriteTx (storage s)
+rwTx = readWriteTx . storage
 
 storageError :: SomeException -> AppError
 storageError = StorageE . StorageError . fmtEx    

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -512,7 +512,7 @@ saveBgps tx DB { bgpStore = BgpStore bgpMap } bgps worldVersion =
 
 deleteBgps :: (MonadIO m, Storage s) => 
             Tx s 'RW -> DB s -> WorldVersion -> m ()
-deleteBgps tx DB { bgpStore = BgpStore m } wv = liftIO $ M.delete tx m wv
+deleteBgps tx DB { bgpStore = BgpStore bgpMap } wv = liftIO $ M.delete tx bgpMap wv
 
 getBgps :: (MonadIO m, Storage s) => 
             Tx s mode -> DB s -> WorldVersion -> m (Maybe (Set.Set BGPSecPayload))
@@ -835,6 +835,7 @@ getDbStats db@DB {..} = liftIO $ roTx db $ \tx -> do
     vrpStats        <- let VRPStore sm = vrpStore in M.stats tx sm
     aspaStats       <- let AspaStore sm = aspaStore in M.stats tx sm
     bgpStats        <- let BgpStore sm = bgpStore in M.stats tx sm
+    gbrStats        <- let GbrStore sm = gbrStore in M.stats tx sm
     metricsStats    <- let MetricStore sm = metricStore in M.stats tx sm
     versionStats    <- let VersionStore sm = versionStore in M.stats tx sm
     sequenceStats   <- M.stats tx sequences

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -28,8 +28,7 @@ import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import qualified Data.Hashable            as H
 import           Data.Text.Encoding       (encodeUtf8)
-import           Data.Typeable
-
+import           Data.Generics.Product.Types
 import           GHC.Generics
 import           Text.Read
 
@@ -65,13 +64,16 @@ import           RPKI.Time
 -- It is brittle and inconvenient, but so far seems to be 
 -- the only realistic option.
 currentDatabaseVersion :: Integer
-currentDatabaseVersion = 14
+currentDatabaseVersion = 16
 
 databaseVersionKey :: Text
 databaseVersionKey = "database-version"
 
 lastValidMftKey :: Text
 lastValidMftKey = "last-valid-mft"
+
+data EraseWrapper s where 
+    EraseWrapper :: forall t s . (Storage s, CanErase s t) => t -> EraseWrapper s
 
 -- All of the stores of the application in one place
 data DB s = DB {
@@ -88,7 +90,8 @@ data DB s = DB {
     slurmStore       :: SlurmStore s,
     jobStore         :: JobStore s,
     sequences        :: SequenceMap s,
-    metadataStore    :: MetadataStore s
+    metadataStore    :: MetadataStore s,
+    erasables        :: [EraseWrapper s]
 } deriving stock (Generic)
 
 instance Storage s => WithStorage s (DB s) where
@@ -126,7 +129,7 @@ data RpkiObjectStore s = RpkiObjectStore {
 
         objectBriefs       :: SMap "object-briefs" s ObjectKey (Compressed EEBrief)
     } 
-    deriving stock (Generic, Typeable)
+    deriving stock (Generic)
 
 
 instance Storage s => WithStorage s (RpkiObjectStore s) where
@@ -135,22 +138,25 @@ instance Storage s => WithStorage s (RpkiObjectStore s) where
 
 -- | TA Store 
 newtype TAStore s = TAStore { 
-    tas :: SMap "trust-anchors" s TaName StorableTA
-}
+        tas :: SMap "trust-anchors" s TaName StorableTA
+    }
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (TAStore s) where
     storage (TAStore s) = storage s
 
 newtype ValidationsStore s = ValidationsStore { 
-    results :: SMap "validations" s WorldVersion (Compressed Validations) 
-}
+        results :: SMap "validations" s WorldVersion (Compressed Validations) 
+    }
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (ValidationsStore s) where
     storage (ValidationsStore s) = storage s
 
 newtype MetricStore s = MetricStore {
-    metrics :: SMap "metrics" s WorldVersion (Compressed RawMetric)
-}
+        metrics :: SMap "metrics" s WorldVersion (Compressed RawMetric)
+    }    
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (MetricStore s) where
     storage (MetricStore s) = storage s
@@ -158,8 +164,9 @@ instance Storage s => WithStorage s (MetricStore s) where
 
 -- | VRP store
 newtype VRPStore s = VRPStore {    
-    vrps :: SMap "vrps" s WorldVersion (Compressed Vrps)
-} deriving Generic
+        vrps :: SMap "vrps" s WorldVersion (Compressed Vrps)
+    }
+    deriving stock (Generic)
 
 -- | ASPA store
 newtype AspaStore s = AspaStore {    
@@ -169,14 +176,15 @@ newtype AspaStore s = AspaStore {
 
 -- | GBR store
 newtype GbrStore s = GbrStore {    
-        aspas :: SMap "gbrs" s WorldVersion (Compressed (Set.Set (Hash, Gbr)))
+        gbrs :: SMap "gbrs" s WorldVersion (Compressed (Set.Set (Hash, Gbr)))
     } 
     deriving stock (Generic)
 
 -- | BGP certificate store
 newtype BgpStore s = BgpStore {    
-    bgps :: SMap "bgps" s WorldVersion (Compressed (Set.Set BGPSecPayload))
-}
+        bgps :: SMap "bgps" s WorldVersion (Compressed (Set.Set BGPSecPayload))
+    }
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (VRPStore s) where
     storage (VRPStore s) = storage s
@@ -184,33 +192,38 @@ instance Storage s => WithStorage s (VRPStore s) where
 
 -- Version store
 newtype VersionStore s = VersionStore {
-    versions :: SMap "versions" s WorldVersion VersionKind
-}
+        versions :: SMap "versions" s WorldVersion VersionKind
+    }
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (VersionStore s) where
     storage (VersionStore s) = storage s
 
 
 newtype SlurmStore s = SlurmStore {
-    slurms :: SMap "slurms" s WorldVersion (Compressed Slurm)
-}
+        slurms :: SMap "slurms" s WorldVersion (Compressed Slurm)
+    }
+    deriving stock (Generic)
 
 data RepositoryStore s = RepositoryStore {
-    rrdpS  :: SMap "rrdp-repositories" s RrdpURL RrdpRepository,
-    rsyncS :: SMap "rsync-repositories" s RsyncHost RsyncNodeNormal,
-    lastS  :: SMap "last-fetch-success" s RpkiURL FetchEverSucceeded
-}
+        rrdpS  :: SMap "rrdp-repositories" s RrdpURL RrdpRepository,
+        rsyncS :: SMap "rsync-repositories" s RsyncHost RsyncNodeNormal,
+        lastS  :: SMap "last-fetch-success" s RpkiURL FetchEverSucceeded
+    }
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (RepositoryStore s) where
     storage (RepositoryStore s _ _) = storage s
 
 newtype JobStore s = JobStore {
-    jobs :: SMap "jobs" s Text Instant
-}
+        jobs :: SMap "jobs" s Text Instant
+    }
+    deriving stock (Generic)
 
 newtype MetadataStore s = MetadataStore {
-    metadata :: SMap "metadata" s Text Text
-}
+        metadata :: SMap "metadata" s Text Text
+    }
+    deriving stock (Generic)
 
 
 getByHash :: (MonadIO m, Storage s) => 
@@ -878,62 +891,13 @@ totalSpace stats =
     let SStats {..} = totalStats stats
     in statKeyBytes + statValueBytes
 
-
+-- Get all SStats and `<>` them
 totalStats :: DBStats -> SStats
-totalStats DBStats {..} = 
-       taStats 
-    <> (let RepositoryStats{..} = repositoryStats 
-        in rrdpStats <> rsyncStats <> lastSStats) 
-    <> (let RpkiObjectStats {..} = rpkiObjectStats
-        in objectsStats <> mftByAKIStats <> hashToKeyStats
-        <> lastValidMftsStats <> uriToUriKeyStat <> uriKeyToUriStat
-        <> uriKeyToObjectKeyStat <> objectKeyToUrlKeysStat
-        <> objectInsertedByStats <> objecBriefStats 
-        <> validatedByVersionStats)
-    <> vResultStats ^. #resultsStats
-    <> vrpStats 
-    <> aspaStats 
-    <> bgpStats 
-    <> gbrStats 
-    <> metricsStats 
-    <> versionStats 
-    <> sequenceStats
-    <> slurmStats
+totalStats = foldOf (types @SStats)
 
--- TODO This is a terribly slow implementation, use
--- drop-based implemntation.
 emptyDBMaps :: (MonadIO m, Storage s) => Tx s 'RW -> DB s -> m ()
-emptyDBMaps tx DB {..} = liftIO $ do     
-    M.erase tx $ tas taStore
-    emptyRepositoryStore repositoryStore    
-    emptyObjectStore objectStore        
-    M.erase tx $ results validationsStore
-    M.erase tx $ vrpStore ^. #vrps 
-    M.erase tx $ aspaStore ^. #aspas
-    M.erase tx $ versions versionStore
-    M.erase tx $ metrics metricStore
-    M.erase tx $ slurms slurmStore
-    M.erase tx $ jobs jobStore    
-  where
-    emptyObjectStore RpkiObjectStore {..} = do   
-        M.erase tx objects
-        M.erase tx hashToKey
-        MM.erase tx mftByAKI
-        M.erase tx lastValidMfts
-        M.erase tx certBySKI
-        M.erase tx objectInsertedBy        
-        M.erase tx validatedByVersion
-        M.erase tx uriToUriKey
-        M.erase tx uriKeyToUri
-        MM.erase tx urlKeyToObjectKey
-        M.erase tx objectKeyToUrlKeys
-        M.erase tx objectBriefs
-
-    emptyRepositoryStore RepositoryStore {..} = do   
-        M.erase tx rrdpS
-        M.erase tx rsyncS
-        M.erase tx lastS
-
+emptyDBMaps tx DB {..} = liftIO $ 
+    forM_ erasables $ \(EraseWrapper t) -> erase tx t
 
 
 -- Utilities to have storage transaction in ValidatorT monad.

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -890,10 +890,15 @@ totalStats DBStats {..} =
         <> uriKeyToObjectKeyStat <> objectKeyToUrlKeysStat
         <> objectInsertedByStats <> objecBriefStats 
         <> validatedByVersionStats)
-    <> resultsStats vResultStats 
+    <> vResultStats ^. #resultsStats
     <> vrpStats 
+    <> aspaStats 
+    <> bgpStats 
+    <> gbrStats 
+    <> metricsStats 
     <> versionStats 
     <> sequenceStats
+    <> slurmStats
 
 -- TODO This is a terribly slow implementation, use
 -- drop-based implemntation.

--- a/src/RPKI/Store/MakeLmdb.hs
+++ b/src/RPKI/Store/MakeLmdb.hs
@@ -97,6 +97,7 @@ createDatabase e logger checkAction = do
         objectKeyToUrlKeys <- SMap lmdb <$> createLmdbStore e
         certBySKI <- SMap lmdb <$> createLmdbStore e
         objectBriefs <- SMap lmdb <$> createLmdbStore e
+        validatedByVersion <- SMap lmdb <$> createLmdbStore e
         pure RpkiObjectStore {..}
             
     createRepositoryStore = 

--- a/src/RPKI/Store/MakeLmdb.hs
+++ b/src/RPKI/Store/MakeLmdb.hs
@@ -8,7 +8,10 @@ module RPKI.Store.MakeLmdb where
 import Control.Lens
 import Control.Concurrent.STM
 
+import           Data.IORef
 import           Data.String.Interpolate.IsString
+
+import           GHC.TypeLits
 
 import           RPKI.Store.Base.Map      (SMap (..))
 import           RPKI.Store.Base.MultiMap (SMultiMap (..))
@@ -31,22 +34,10 @@ data DbCheckResult = WasIncompatible | WasCompatible | DidntHaveVersion
 
 createDatabase :: LmdbEnv -> AppLogger -> IncompatibleDbCheck -> IO (DB LmdbStorage, DbCheckResult)
 createDatabase e logger checkAction = do 
-    sequences <- SMap lmdb <$> createLmdbStore e
-    taStore          <- createTAStore
-    repositoryStore  <- createRepositoryStore
-    objectStore      <- createObjectStore sequences    
-    validationsStore <- createValidationsStore
-    vrpStore         <- createVRPStore    
-    aspaStore        <- createAspaStore
-    gbrStore         <- createGbrStore
-    bgpStore         <- createBgpStore
-    versionStore     <- createVersionStore
-    metricStore      <- createMetricsStore
-    slurmStore       <- createSlurmStore
-    jobStore         <- createJobStore        
-    metadataStore    <- createMetadataStore
+
+    erasables <- newIORef []
+    db :: DB LmdbStorage <- doCreate erasables
     
-    let db = DB {..}
     case checkAction of     
         CheckVersion -> do 
             dbCheck <- verifyDBVersion db
@@ -82,41 +73,58 @@ createDatabase e logger checkAction = do
                     else
                         pure WasCompatible
 
-    createObjectStore seqMap = do 
-        let keys = Sequence "object-key" seqMap
-        objects  <- SMap lmdb <$> createLmdbStore e
-        mftByAKI <- SMultiMap lmdb <$> createLmdbMultiStore e
-        objectInsertedBy <- SMap lmdb <$> createLmdbStore e        
-        hashToKey   <- SMap lmdb <$> createLmdbStore e
-        lastValidMfts <- SMap lmdb <$> createLmdbStore e
+    doCreate :: IORef [EraseWrapper LmdbStorage] -> IO (DB LmdbStorage)
+    doCreate erasablesRef = do 
+        sequences        <- createMap
+        taStore          <- TAStore <$> createMap        
+        validationsStore <- ValidationsStore <$> createMap
+        vrpStore         <- VRPStore <$> createMap    
+        aspaStore        <- AspaStore <$> createMap    
+        gbrStore         <- GbrStore <$> createMap 
+        bgpStore         <- BgpStore <$> createMap
+        versionStore     <- VersionStore <$> createMap
+        metricStore      <- MetricStore <$> createMap
+        slurmStore       <- SlurmStore <$> createMap
+        jobStore         <- JobStore <$> createMap        
+        metadataStore    <- MetadataStore <$> createMap          
+        repositoryStore  <- createRepositoryStore
+        objectStore      <- createObjectStore sequences            
 
-        uriToUriKey <- SMap lmdb <$> createLmdbStore e
-        uriKeyToUri <- SMap lmdb <$> createLmdbStore e
-        urlKeyToObjectKey  <- SMultiMap lmdb <$> createLmdbMultiStore e
-        objectKeyToUrlKeys <- SMap lmdb <$> createLmdbStore e
-        certBySKI <- SMap lmdb <$> createLmdbStore e
-        objectBriefs <- SMap lmdb <$> createLmdbStore e
-        validatedByVersion <- SMap lmdb <$> createLmdbStore e        
-        pure RpkiObjectStore {..}
+        erasables <- readIORef erasablesRef
+
+        pure DB {..}
+      where
+
+        createObjectStore seqMap = do 
+            let keys = Sequence "object-key" seqMap
+            objects          <- createMap
+            mftByAKI         <- createMultiMap
+            objectInsertedBy <- createMap        
+            hashToKey        <- createMap
+            lastValidMfts    <- createMap
+            uriToUriKey      <- createMap
+            uriKeyToUri      <- createMap
+            urlKeyToObjectKey  <- createMultiMap
+            objectKeyToUrlKeys <- createMap
+            certBySKI          <- createMap
+            objectBriefs       <- createMap
+            validatedByVersion <- createMap        
+            pure RpkiObjectStore {..}
             
-    createRepositoryStore = 
-        RepositoryStore <$>
-            (SMap lmdb <$> createLmdbStore e) <*>
-            (SMap lmdb <$> createLmdbStore e) <*>
-            (SMap lmdb <$> createLmdbStore e)        
-    
-    createValidationsStore = ValidationsStore . SMap lmdb <$> createLmdbStore e
-    createVRPStore = VRPStore . SMap lmdb <$> createLmdbStore e    
-    createAspaStore = AspaStore . SMap lmdb <$> createLmdbStore e    
-    createGbrStore  = GbrStore . SMap lmdb <$> createLmdbStore e    
-    createBgpStore = BgpStore . SMap lmdb <$> createLmdbStore e    
-    createTAStore = TAStore . SMap lmdb <$> createLmdbStore e    
-    createVersionStore = VersionStore . SMap lmdb <$> createLmdbStore e    
-    createMetricsStore = MetricStore . SMap lmdb <$> createLmdbStore e    
-    createSlurmStore = SlurmStore . SMap lmdb <$> createLmdbStore e    
-    createJobStore = JobStore . SMap lmdb <$> createLmdbStore e    
-    createMetadataStore = MetadataStore . SMap lmdb <$> createLmdbStore e    
-    
+        createRepositoryStore = RepositoryStore <$> createMap <*> createMap <*> createMap      
+        
+        createMap :: forall k v name . (KnownSymbol name) => IO (SMap name LmdbStorage k v)
+        createMap = do 
+            sm <- SMap lmdb <$> createLmdbStore e
+            modifyIORef' erasablesRef (EraseWrapper sm :)
+            pure sm
+
+        createMultiMap :: forall k v name . (KnownSymbol name) => IO (SMultiMap name LmdbStorage k v)
+        createMultiMap = do 
+            sm <- SMultiMap lmdb <$> createLmdbMultiStore e
+            modifyIORef' erasablesRef (EraseWrapper sm :)
+            pure sm
+        
 
 mkLmdb :: FilePath -> Config -> IO LmdbEnv
 mkLmdb fileName config = do 

--- a/src/RPKI/Store/MakeLmdb.hs
+++ b/src/RPKI/Store/MakeLmdb.hs
@@ -89,7 +89,7 @@ createDatabase e logger checkAction = do
         objectInsertedBy <- SMap lmdb <$> createLmdbStore e
         objectValidatedBy <- SMap lmdb <$> createLmdbStore e        
         hashToKey   <- SMap lmdb <$> createLmdbStore e
-        lastValidMft <- SMap lmdb <$> createLmdbStore e
+        lastValidMfts <- SMap lmdb <$> createLmdbStore e
 
         uriToUriKey <- SMap lmdb <$> createLmdbStore e
         uriKeyToUri <- SMap lmdb <$> createLmdbStore e
@@ -97,7 +97,7 @@ createDatabase e logger checkAction = do
         objectKeyToUrlKeys <- SMap lmdb <$> createLmdbStore e
         certBySKI <- SMap lmdb <$> createLmdbStore e
         objectBriefs <- SMap lmdb <$> createLmdbStore e
-        validatedByVersion <- SMap lmdb <$> createLmdbStore e
+        validatedByVersion <- SMap lmdb <$> createLmdbStore e        
         pure RpkiObjectStore {..}
             
     createRepositoryStore = 

--- a/src/RPKI/Store/MakeLmdb.hs
+++ b/src/RPKI/Store/MakeLmdb.hs
@@ -86,8 +86,7 @@ createDatabase e logger checkAction = do
         let keys = Sequence "object-key" seqMap
         objects  <- SMap lmdb <$> createLmdbStore e
         mftByAKI <- SMultiMap lmdb <$> createLmdbMultiStore e
-        objectInsertedBy <- SMap lmdb <$> createLmdbStore e
-        objectValidatedBy <- SMap lmdb <$> createLmdbStore e        
+        objectInsertedBy <- SMap lmdb <$> createLmdbStore e        
         hashToKey   <- SMap lmdb <$> createLmdbStore e
         lastValidMfts <- SMap lmdb <$> createLmdbStore e
 

--- a/src/RPKI/Store/Sequence.hs
+++ b/src/RPKI/Store/Sequence.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
@@ -22,9 +24,10 @@ newtype SequenceValue = SequenceValue Int64
 type SequenceMap s = SMap "sequences" s Text SequenceValue
 
 data Sequence s = Sequence {
-    sequenceName :: Text,
-    sequenceMap :: SMap "sequences" s Text SequenceValue
-}
+        sequenceName :: Text,
+        sequenceMap :: SMap "sequences" s Text SequenceValue
+    } 
+    deriving stock (Generic)
 
 instance Storage s => WithStorage s (Sequence s) where
     storage (Sequence _ s) = storage s

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -56,6 +56,10 @@ newtype SafeUrlAsKey = SafeUrlAsKey BSS.ShortByteString
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary)        
 
+data Keyed a = Keyed a ObjectKey
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary)        
+
 data RpkiObjectStats = RpkiObjectStats {
     objectsStats       :: SStats,
     mftByAKIStats      :: SStats,    

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -95,6 +95,7 @@ data DBStats = DBStats {
     vrpStats        :: SStats,        
     aspaStats       :: SStats,        
     bgpStats        :: SStats,        
+    gbrStats        :: SStats,        
     metricsStats    :: SStats,    
     versionStats    :: SStats,    
     sequenceStats   :: SStats,

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -65,8 +65,7 @@ data RpkiObjectStats = RpkiObjectStats {
     uriKeyToUriStat    :: SStats,
     uriKeyToObjectKeyStat  :: SStats,
     objectKeyToUrlKeysStat :: SStats,
-    objectInsertedByStats  :: SStats,
-    objectValidatedByStats  :: SStats,
+    objectInsertedByStats  :: SStats,    
     objecBriefStats         :: SStats,
     validatedByVersionStats :: SStats
 } deriving stock (Show, Eq, Generic)

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -56,7 +56,10 @@ newtype SafeUrlAsKey = SafeUrlAsKey BSS.ShortByteString
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary)        
 
-data Keyed a = Keyed a ObjectKey
+data Keyed a = Keyed { 
+        object :: a,
+        key    :: ObjectKey
+    }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary)        
 

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -60,7 +60,7 @@ data RpkiObjectStats = RpkiObjectStats {
     objectsStats       :: SStats,
     mftByAKIStats      :: SStats,    
     hashToKeyStats     :: SStats,
-    lastValidMftStats  :: SStats,
+    lastValidMftsStats :: SStats,
     uriToUriKeyStat    :: SStats,
     uriKeyToUriStat    :: SStats,
     uriKeyToObjectKeyStat  :: SStats,

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -22,7 +22,6 @@ import           RPKI.Config
 import           RPKI.Store.Base.Storable
 import           RPKI.Store.Base.Serialisation
 
-
 data StorableTA = StorableTA {
     tal                 :: TAL,
     taCert              :: CaCerObject,
@@ -68,7 +67,8 @@ data RpkiObjectStats = RpkiObjectStats {
     objectKeyToUrlKeysStat :: SStats,
     objectInsertedByStats  :: SStats,
     objectValidatedByStats  :: SStats,
-    objecBriefStats         :: SStats
+    objecBriefStats         :: SStats,
+    validatedByVersionStats :: SStats
 } deriving stock (Show, Eq, Generic)
 
 data VResultStats = VResultStats {     

--- a/src/RPKI/Validation/BottomUp.hs
+++ b/src/RPKI/Validation/BottomUp.hs
@@ -152,7 +152,7 @@ validateBottomUp
         let certLocations = getLocations certificate                
         maybeMft <- liftIO $ roTx db $ \tx -> findLatestMftByAKI tx db childrenAki
         let tryLatestValid = tryLatestValidCachedManifest appContext useManifest 
-                                (fst <$> maybeMft) validManifests childrenAki certLocations
+                                ((^. #object) <$> maybeMft) validManifests childrenAki certLocations
         case maybeMft of 
             Nothing -> 
                 vError (NoMFT childrenAki certLocations) `catchError` tryLatestValid                
@@ -161,7 +161,8 @@ validateBottomUp
       where 
         -- TODO Decide what to do with nested scopes (we go bottom up, 
         -- so nesting doesn't work the same way).
-        useManifest (locatedMft, _) childrenAki certLocations = do 
+        useManifest keyedMft childrenAki certLocations = do 
+            let locatedMft = keyedMft ^. #object
             let mft = locatedMft ^. #payload            
             validateObjectLocations locatedMft
             validateMftLocation locatedMft certificate

--- a/src/RPKI/Validation/Common.hs
+++ b/src/RPKI/Validation/Common.hs
@@ -83,14 +83,6 @@ findLatestMft database childrenAki = liftIO $ do
     roTx objectStore' $ \tx -> 
         findLatestMftByAKI tx objectStore' childrenAki
 
--- findLatestCachedValidMft :: (MonadIO m, HasField' "objectStore" s1 (RpkiObjectStore s), Storage s) =>
---                 TVar s1 -> AKI -> m (Maybe (Located MftObject))
--- findLatestCachedValidMft database childrenAki = liftIO $ do 
---     objectStore' <- (^. #objectStore) <$> readTVarIO database
---     roTx objectStore' $ \tx -> 
---         getLatestValidMftByAKI tx objectStore' childrenAki
-
-
 -- 
 -- Reusable piece for the cases when a "fetch" has failed so we are falling 
 -- back to a latest valid cached manifest for this CA
@@ -109,9 +101,7 @@ tryLatestValidCachedManifest :: (MonadIO m, Storage s, WithHash mft) =>
     -> AppError
     -> ValidatorT m b
 tryLatestValidCachedManifest AppContext{..} useManifest latestMft validManifests childrenAki certLocations e = do
-    db <- liftIO $ readTVarIO database
-    -- z <- roTx objectStore' $ \tx -> 
-    --         getLatestValidMftByAKI tx objectStore' childrenAki
+    db        <- liftIO $ readTVarIO database
     validMfts <- loadValidManifests db validManifests    
     case Map.lookup childrenAki validMfts of
         Nothing   -> throwError e

--- a/src/RPKI/Validation/Common.hs
+++ b/src/RPKI/Validation/Common.hs
@@ -86,7 +86,7 @@ validateMftFileName filename =
 -- 
 tryLatestValidCachedManifest :: (MonadIO m, Storage s, WithHash mft) =>
         AppContext s
-    -> ((Located MftObject, ObjectKey) -> AKI -> Locations -> ValidatorT m b)
+    -> (Keyed (Located MftObject) -> AKI -> Locations -> ValidatorT m b)
     -> Maybe mft
     -> TVar ValidManifests
     -> AKI
@@ -108,7 +108,7 @@ tryLatestValidCachedManifest AppContext{..} useManifest latestMft validManifests
                 Nothing -> do 
                     appWarn e      
                     logWarn logger [i|Failed to process manifest #{mftLoc}: #{e}, will try previous valid version.|]
-                    useManifest (latestValidMft, key) childrenAki certLocations                                
+                    useManifest (Keyed latestValidMft key) childrenAki certLocations                                
                 Just latestMft'
                     | getHash latestMft' == getHash latestValidMft
                         -- it doesn't make sense to try the same manifest again
@@ -118,7 +118,7 @@ tryLatestValidCachedManifest AppContext{..} useManifest latestMft validManifests
                         appWarn e                                    
                         logWarn logger $ [i|Failed to process latest manifest #{mftLoc}: #{e},|] <> 
                                          [i|] fetch is invalid, will try latest valid one from previous fetch(es).|]
-                        useManifest (latestValidMft, key) childrenAki certLocations
+                        useManifest (Keyed latestValidMft key) childrenAki certLocations
 
 
 loadValidManifests :: (MonadIO m, Storage s) => 

--- a/src/RPKI/Validation/TopDown.hs
+++ b/src/RPKI/Validation/TopDown.hs
@@ -22,7 +22,7 @@ import           GHC.Generics (Generic)
 
 import           Data.Either                      (fromRight, partitionEithers)
 import           Data.Foldable
-import           Data.IORef 
+import           Data.IORef
 import qualified Data.Set.NonEmpty                as NESet
 import qualified Data.Map.Strict                  as Map
 import qualified Data.Map.Monoidal.Strict         as MonoidalMap
@@ -61,27 +61,27 @@ import           RPKI.Validation.Common
 
 -- Auxiliarry structure used in top-down validation. It has a lot of global variables 
 -- but it's lifetime is limited to one top-down validation run.
-data TopDownContext = TopDownContext {    
-        verifiedResources       :: Maybe (VerifiedRS PrefixesAndAsns),    
-        taName                  :: TaName,         
+data TopDownContext = TopDownContext {
+        verifiedResources       :: Maybe (VerifiedRS PrefixesAndAsns),
+        taName                  :: TaName,
         allTas                  :: AllTasTopDownContext,
         currentPathDepth        :: Int,
         startingRepositoryCount :: Int,
         interruptedByLimit      :: TVar Limited
     }
-    deriving stock (Generic)    
+    deriving stock (Generic)
 
 
-data AllTasTopDownContext = AllTasTopDownContext {                    
+data AllTasTopDownContext = AllTasTopDownContext {
         now                  :: Now,
         worldVersion         :: WorldVersion,
         validManifests       :: TVar ValidManifests,
-        visitedHashes        :: TVar (Set Hash),        
-        hash2Key             :: TVar (Map.Map Hash ObjectKey),        
-        repositoryProcessing :: RepositoryProcessing,        
+        visitedHashes        :: TVar (Set Hash),
+        hash2Key             :: TVar (Map.Map Hash ObjectKey),
+        repositoryProcessing :: RepositoryProcessing,
         briefs               :: TVar [BriefUpdate]
     }
-    deriving stock (Generic)    
+    deriving stock (Generic)
 
 
 data Limited = CanProceed | FirstToHitLimit | AlreadyReportedLimit
@@ -94,37 +94,37 @@ data ObjectOrBrief = RObject (Located RpkiObject) | RBrief (Located EEBrief) Has
     deriving stock (Show, Eq, Generic)
 
 data TopDownResult = TopDownResult {
-        payloads           :: Payloads Vrps,        
+        payloads           :: Payloads Vrps,
         topDownValidations :: ValidationState
     }
     deriving stock (Show, Eq, Ord, Generic)
-    deriving Semigroup via GenericSemigroup TopDownResult   
-    deriving Monoid    via GenericMonoid TopDownResult       
+    deriving Semigroup via GenericSemigroup TopDownResult
+    deriving Monoid    via GenericMonoid TopDownResult
 
 
 fromValidations :: ValidationState -> TopDownResult
 fromValidations = TopDownResult mempty
 
 
-newTopDownContext :: MonadIO m => 
-                    TaName                     
-                    -> CaCerObject 
+newTopDownContext :: MonadIO m =>
+                    TaName
+                    -> CaCerObject
                     -> AllTasTopDownContext
                     -> m TopDownContext
-newTopDownContext taName certificate allTas = 
-    liftIO $ atomically $ do    
-        let verifiedResources = Just $ createVerifiedResources certificate        
-        let currentPathDepth = 0        
-        startingRepositoryCount <- fmap repositoryCount $ readTVar $ allTas ^. #repositoryProcessing . #publicationPoints  
-        interruptedByLimit      <- newTVar CanProceed                
+newTopDownContext taName certificate allTas =
+    liftIO $ atomically $ do
+        let verifiedResources = Just $ createVerifiedResources certificate
+        let currentPathDepth = 0
+        startingRepositoryCount <- fmap repositoryCount $ readTVar $ allTas ^. #repositoryProcessing . #publicationPoints
+        interruptedByLimit      <- newTVar CanProceed
         pure $ TopDownContext {..}
 
-newAllTasTopDownContext :: MonadIO m => 
-                        WorldVersion                        
-                        -> Now 
-                        -> RepositoryProcessing                    
+newAllTasTopDownContext :: MonadIO m =>
+                        WorldVersion
+                        -> Now
+                        -> RepositoryProcessing
                         -> m AllTasTopDownContext
-newAllTasTopDownContext worldVersion now repositoryProcessing = 
+newAllTasTopDownContext worldVersion now repositoryProcessing =
     liftIO $ atomically $ do
         visitedHashes  <- newTVar mempty
         hash2Key       <- newTVar mempty
@@ -133,103 +133,103 @@ newAllTasTopDownContext worldVersion now repositoryProcessing =
         pure $ AllTasTopDownContext {..}
 
 newRepositoryContext :: PublicationPoints -> RepositoryContext
-newRepositoryContext publicationPoints = let 
-    takenCareOf = Set.empty 
+newRepositoryContext publicationPoints = let
+    takenCareOf = Set.empty
     in RepositoryContext {..}
 
 
 verifyLimit :: STM Bool -> TVar Limited -> STM Limited
 verifyLimit hitTheLimit limit =
-    readTVar limit >>= \case    
-        CanProceed -> do 
+    readTVar limit >>= \case
+        CanProceed -> do
             h <- hitTheLimit
             if h then do
                 writeTVar limit FirstToHitLimit
                 pure FirstToHitLimit
-            else 
+            else
                 pure CanProceed
-        FirstToHitLimit -> do 
+        FirstToHitLimit -> do
             writeTVar limit AlreadyReportedLimit
             pure AlreadyReportedLimit
-        AlreadyReportedLimit -> 
+        AlreadyReportedLimit ->
             pure AlreadyReportedLimit
 
 -- | It is the main entry point for the top-down validation. 
 -- Validates a bunch of TAs starting from their TALs.  
-validateMutlipleTAs :: Storage s => 
-                    AppContext s 
-                    -> WorldVersion 
+validateMutlipleTAs :: Storage s =>
+                    AppContext s
+                    -> WorldVersion
                     -> [TAL]
                     -> IO [TopDownResult]
-validateMutlipleTAs appContext@AppContext {..} worldVersion tals = do                                     
-    db <- readTVarIO database 
+validateMutlipleTAs appContext@AppContext {..} worldVersion tals = do
+    db <- readTVarIO database
 
-    repositoryProcessing <- newRepositoryProcessingIO config        
-    allTas <- newAllTasTopDownContext worldVersion 
+    repositoryProcessing <- newRepositoryProcessingIO config
+    allTas <- newAllTasTopDownContext worldVersion
                 (Now $ versionToMoment worldVersion) repositoryProcessing
-    
-    validateThem db allTas 
-        `finally` 
-            concurrently 
+
+    validateThem db allTas
+        `finally`
+            concurrently
                 (applyValidationSideEffects appContext allTas)
                 (cancelFetchTasks repositoryProcessing)
   where
 
-    validateThem db allTas = do 
+    validateThem db allTas = do
         -- set initial publication point state
-        mapException (AppException . storageError) $ do             
+        mapException (AppException . storageError) $ do
             pps <- roTx db $ \tx -> getPublicationPoints tx db
             let pps' = addRsyncPrefetchUrls config pps
             atomically $ writeTVar (allTas ^. #repositoryProcessing . #publicationPoints) pps'
-     
-        rs <- liftIO $ pooledForConcurrently tals $ \tal -> do           
-            (r@TopDownResult{ payloads = Payloads {..}}, elapsed) <- timedMS $ 
+
+        rs <- liftIO $ pooledForConcurrently tals $ \tal -> do
+            (r@TopDownResult{ payloads = Payloads {..}}, elapsed) <- timedMS $
                     validateTA appContext tal worldVersion allTas
             logInfo logger [i|Validated TA '#{getTaName tal}', got #{estimateVrpCount vrps} VRPs, took #{elapsed}ms|]
-            pure r    
+            pure r
 
         -- save publication points state    
-        mapException (AppException . storageError) $ do            
-            pps <- readTVarIO $ allTas ^. #repositoryProcessing . #publicationPoints    
-            rwTx db $ \tx -> savePublicationPoints tx db pps            
+        mapException (AppException . storageError) $ do
+            pps <- readTVarIO $ allTas ^. #repositoryProcessing . #publicationPoints
+            rwTx db $ \tx -> savePublicationPoints tx db pps
 
         -- Get validations for all the fetches that happened during this top-down traversal
         fetchValidation <- validationStateOfFetches $ allTas ^. #repositoryProcessing
-        pure $ fromValidations fetchValidation : rs              
+        pure $ fromValidations fetchValidation : rs
 
 --
-validateTA :: Storage s => 
-            AppContext s 
-            -> TAL 
-            -> WorldVersion             
-            -> AllTasTopDownContext             
+validateTA :: Storage s =>
+            AppContext s
+            -> TAL
+            -> WorldVersion
+            -> AllTasTopDownContext
             -> IO TopDownResult
-validateTA appContext@AppContext{..} tal worldVersion allTas = do    
+validateTA appContext@AppContext{..} tal worldVersion allTas = do
     let maxDuration = config ^. typed @ValidationConfig . #topDownTimeout
-    (r, vs) <- runValidatorT taContext $ 
-            timeoutVT 
+    (r, vs) <- runValidatorT taContext $
+            timeoutVT
                 maxDuration
                 validateFromTAL
-                (do 
+                (do
                     logError logger [i|Validation for TA #{taName} did not finish within #{maxDuration} and was interrupted.|]
-                    appError $ ValidationE $ ValidationTimeout $ secondsToInt maxDuration) 
-    
-    let payloads = case r of 
+                    appError $ ValidationE $ ValidationTimeout $ secondsToInt maxDuration)
+
+    let payloads = case r of
                     Left _  -> mempty
                     Right p -> p & #vrps %~ newVrps taName
-    
+
     pure $ TopDownResult payloads vs
   where
     taName = getTaName tal
     taContext = newScopes' TAFocus $ unTaName taName
 
-    validateFromTAL = do 
-        timedMetric (Proxy :: Proxy ValidationMetric) $ 
-            inSubObjectVScope (toText $ getTaCertURL tal) $ do 
+    validateFromTAL = do
+        timedMetric (Proxy :: Proxy ValidationMetric) $
+            inSubObjectVScope (toText $ getTaCertURL tal) $ do
                 ((taCert, repos, _), _) <- timedMS $ validateTACertificateFromTAL appContext tal worldVersion
                 -- this will be used as the "now" in all subsequent time and period validations                 
                 topDownContext <- newTopDownContext taName (taCert ^. #payload) allTas
-                validateFromTACert appContext topDownContext repos taCert                
+                validateFromTACert appContext topDownContext repos taCert
 
 
 data TACertStatus = Existing | Updated
@@ -237,14 +237,14 @@ data TACertStatus = Existing | Updated
 -- | Fetch and validated TA certificate starting from the TAL.
 -- | 
 -- | This function doesn't throw exceptions.
-validateTACertificateFromTAL :: Storage s => 
-                                AppContext s 
-                                -> TAL 
-                                -> WorldVersion 
+validateTACertificateFromTAL :: Storage s =>
+                                AppContext s
+                                -> TAL
+                                -> WorldVersion
                                 -> ValidatorT IO (Located CaCerObject, PublicationPointAccess, TACertStatus)
 validateTACertificateFromTAL appContext@AppContext {..} tal worldVersion = do
     let now = Now $ versionToMoment worldVersion
-    let validationConfig = config ^. typed @ValidationConfig    
+    let validationConfig = config ^. typed @ValidationConfig
 
     taStore  <- taStore <$> liftIO (readTVarIO database)
     taByName <- roAppTxEx taStore storageError $ \tx -> getTA tx taStore (getTaName tal)
@@ -257,20 +257,20 @@ validateTACertificateFromTAL appContext@AppContext {..} tal worldVersion = do
                 logInfo logger [i|Not re-fetching TA certificate #{getURL $ getTaCertURL tal}, it's up-to-date.|]
                 pure (locatedTaCert (getTaCertURL tal) taCert, initialRepositories, Existing)
   where
-    fetchValidateAndStore taStore (Now moment) previousCert = do 
+    fetchValidateAndStore taStore (Now moment) previousCert = do
         (uri', ro) <- fetchTACertificate appContext tal
-        cert       <- vHoist $ validateTACert tal uri' ro            
+        cert       <- vHoist $ validateTACert tal uri' ro
         -- Check for replay attacks
-        actualCert <- case previousCert of 
+        actualCert <- case previousCert of
                         Nothing       -> pure cert
                         Just previous -> vHoist $ validateTACertWithPreviousCert cert previous
         case publicationPointsFromTAL tal actualCert of
             Left e         -> appError $ ValidationE e
-            Right ppAccess -> 
-                rwAppTxEx taStore storageError $ \tx -> do 
+            Right ppAccess ->
+                rwAppTxEx taStore storageError $ \tx -> do
                     saveTA tx taStore (StorableTA tal actualCert (FetchedAt moment) ppAccess)
                     pure (locatedTaCert uri' actualCert, ppAccess, Updated)
-            
+
     locatedTaCert url cert = Located (toLocations url) cert
 
 
@@ -278,60 +278,44 @@ validateTACertificateFromTAL appContext@AppContext {..} tal worldVersion = do
 -- | 
 -- | This function doesn't throw exceptions.
 validateFromTACert :: Storage s =>
-                    AppContext s -> 
-                    TopDownContext ->  
-                    PublicationPointAccess -> 
-                    Located CaCerObject ->                     
+                    AppContext s ->
+                    TopDownContext ->
+                    PublicationPointAccess ->
+                    Located CaCerObject ->
                     ValidatorT IO (Payloads (Set Vrp))
-validateFromTACert 
+validateFromTACert
     appContext@AppContext {..}
-    topDownContext@TopDownContext { allTas = AllTasTopDownContext {..}, .. } 
+    topDownContext@TopDownContext { allTas = AllTasTopDownContext {..}, .. }
     initialRepos
-    taCert 
-  = do      
-    for_ (filterPPAccess config initialRepos) $ \filteredRepos -> do        
-        liftIO $ atomically $ modifyTVar' 
+    taCert
+  = do
+    for_ (filterPPAccess config initialRepos) $ \filteredRepos -> do
+        liftIO $ atomically $ modifyTVar'
                     (repositoryProcessing ^. #publicationPoints)
-                    (\pubPoints -> foldr mergePP pubPoints $ unPublicationPointAccess filteredRepos) 
-        
+                    (\pubPoints -> foldr mergePP pubPoints $ unPublicationPointAccess filteredRepos)
+
         -- ignore return result here, because all the fetching statuses will be
         -- handled afterwards by getting them from `repositoryProcessing` 
         void $ fetchPPWithFallback appContext repositoryProcessing worldVersion filteredRepos
-        
-    -- Do the tree descend, gather validation results and VRPs            
-    vp <- askScopes
-    T2 payloads validationState <- fromTry 
-                (\e -> UnspecifiedE (unTaName taName) (fmtEx e)) 
-                (validateCA appContext vp topDownContext taCert)
 
-    embedState validationState    
+    -- Do the tree descend, gather validation results and VRPs                
+    payloads <- fromTryM
+                (UnspecifiedE (unTaName taName) . fmtEx)
+                (validateCa appContext topDownContext taCert)
+
     pure $! foldr (<>) mempty payloads
-         
 
--- | Validate CA starting from its certificate.
--- 
-validateCA :: Storage s =>
-            AppContext s 
-            -> Scopes 
-            -> TopDownContext 
-            -> Located CaCerObject 
-            -> IO (T2 (Seq (Payloads (Set Vrp))) ValidationState)
-validateCA appContext scopes topDownContext certificate = do             
-    (r, validations) <- runValidatorT scopes $
-                            validateCaCertificate appContext topDownContext certificate        
-    pure $! T2 (fromRight mempty r) validations
-    
 
-validateCaCertificate :: Storage s =>
+validateCa :: Storage s =>
                         AppContext s ->
                         TopDownContext ->
-                        Located CaCerObject ->                
+                        Located CaCerObject ->
                         ValidatorT IO (Seq (Payloads (Set Vrp)))
-validateCaCertificate 
-    appContext@AppContext {..} 
-    topDownContext@TopDownContext { allTas = AllTasTopDownContext {..}, .. } 
-    certificate = do          
-    
+validateCa
+    appContext@AppContext {..}
+    topDownContext@TopDownContext { allTas = AllTasTopDownContext {..}, .. }
+    certificate = do
+
     let validationConfig = config ^. typed @ValidationConfig
 
     -- First check if we have reached some limit for the total depth of the CA tree
@@ -340,55 +324,55 @@ validateCaCertificate
     -- Check and report for the maximal tree depth
     let treeDepthLimit = (
             pure (currentPathDepth > validationConfig ^. #maxCertificatePathDepth),
-            do 
+            do
                 logError logger [i|Interrupting validation on #{fmtLocations $ getLocations certificate}, maximum tree depth is reached.|]
-                vError $ CertificatePathTooDeep 
-                            (getLocations certificate) 
+                vError $ CertificatePathTooDeep
+                            (getLocations certificate)
                             (validationConfig ^. #maxCertificatePathDepth)
             )
 
     -- Check and report for the maximal number of objects in the tree
     let visitedObjectCountLimit = (
             (> validationConfig ^. #maxTotalTreeSize) . Set.size <$> readTVar visitedHashes,
-            do 
+            do
                 logError logger [i|Interrupting validation on #{fmtLocations $ getLocations certificate}, maximum total object number in the tree is reached.|]
-                vError $ TreeIsTooBig 
-                            (getLocations certificate) 
+                vError $ TreeIsTooBig
+                            (getLocations certificate)
                             (validationConfig ^. #maxTotalTreeSize)
             )
 
     -- Check and report for the maximal increase in the repository number
     let repositoryCountLimit = (
-            do 
+            do
                 pps <- readTVar $ repositoryProcessing ^. #publicationPoints
                 pure $ repositoryCount pps - startingRepositoryCount > validationConfig ^. #maxTaRepositories,
-            do 
+            do
                 logError logger [i|Interrupting validation on #{fmtLocations $ getLocations certificate}, maximum total new repository count is reached.|]
-                vError $ TooManyRepositories 
-                            (getLocations certificate) 
+                vError $ TooManyRepositories
+                            (getLocations certificate)
                             (validationConfig ^. #maxTaRepositories)
             )
-                
-    let actuallyValidate = 
-            case getPublicationPointsFromCertObject (certificate ^. #payload) of            
+
+    let actuallyValidate =
+            case getPublicationPointsFromCertObject (certificate ^. #payload) of
                 Left e         -> vError e
-                Right ppAccess ->   
-                    case filterPPAccess config ppAccess of 
-                        Nothing -> 
+                Right ppAccess ->
+                    case filterPPAccess config ppAccess of
+                        Nothing ->
                             -- Both rrdp and rsync (and whatever else in the future?) are
                             -- disabled, don't fetch at all.
                             validateThisCertAndGoDown
-                        Just filteredPPAccess -> do 
+                        Just filteredPPAccess -> do
                             fetches    <- fetchPPWithFallback appContext repositoryProcessing worldVersion filteredPPAccess
                             primaryUrl <- getPrimaryRepositoryFromPP repositoryProcessing filteredPPAccess
-                            let goFurther = 
-                                    if anySuccess fetches                    
-                                        then validateThisCertAndGoDown                            
-                                        else do                             
-                                            fetchEverSucceeded repositoryProcessing filteredPPAccess >>= \case                        
+                            let goFurther =
+                                    if anySuccess fetches
+                                        then validateThisCertAndGoDown
+                                        else do
+                                            fetchEverSucceeded repositoryProcessing filteredPPAccess >>= \case
                                                 Never       -> pure mempty
-                                                AtLeastOnce -> validateThisCertAndGoDown                            
-                            case primaryUrl of 
+                                                AtLeastOnce -> validateThisCertAndGoDown
+                            case primaryUrl of
                                 Nothing -> goFurther
                                 Just rp -> inSubMetricScope' PPFocus rp goFurther
 
@@ -396,19 +380,19 @@ validateCaCertificate
     -- is reported only by the thread that first hits it
     let checkAndReport (condition, report) nextOne = do
             z <- liftIO $ atomically $ verifyLimit condition interruptedByLimit
-            case z of 
+            case z of
                 CanProceed           -> nextOne
                 FirstToHitLimit      -> report
                 AlreadyReportedLimit -> pure mempty
 
-    checkAndReport treeDepthLimit 
-        $ checkAndReport visitedObjectCountLimit 
+    checkAndReport treeDepthLimit
+        $ checkAndReport visitedObjectCountLimit
         $ checkAndReport repositoryCountLimit
         $ actuallyValidate
 
-  where    
-    
-    validateThisCertAndGoDown = do            
+  where
+
+    validateThisCertAndGoDown = do
         -- Here we do the following
         -- 
         --  1) get the latest manifest (latest by the validity period)
@@ -424,37 +408,37 @@ validateCaCertificate
         -- Everything else is either extra checks or metrics.
         --         
         let childrenAki   = toAKI $ getSKI certificate
-        let certLocations = getLocations certificate        
-        
+        let certLocations = getLocations certificate
+
         validateObjectLocations certificate
 
-        oneMoreCert            
-        visitObject topDownContext (CerRO $ certificate ^. #payload)                                                    
+        oneMoreCert
+        visitObject topDownContext (CerRO $ certificate ^. #payload)
 
         -- first try to use the latest manifest 
         -- https://datatracker.ietf.org/doc/html/draft-ietf-sidrops-6486bis-11#section-6.2
         --         
-        maybeMft <- liftIO $ do 
+        maybeMft <- liftIO $ do
                         db <- readTVarIO database
-                        roTx db $ \tx -> findLatestMftByAKI tx db childrenAki                        
-        let goForLatestValid = tryLatestValidCachedManifest appContext useManifest 
+                        roTx db $ \tx -> findLatestMftByAKI tx db childrenAki
+        let goForLatestValid = tryLatestValidCachedManifest appContext useManifest
                                 ((^. #object) <$> maybeMft) validManifests childrenAki certLocations
-        case maybeMft of                        
-            Nothing -> 
+        case maybeMft of
+            Nothing ->
                 -- Use awkward vError + catchError to force the error to 
                 -- get into the Validations in the state.
                 vError (NoMFT childrenAki certLocations)
                     `catchError`
                     goForLatestValid
-                
-            Just mft -> 
+
+            Just mft ->
                 useManifest mft childrenAki certLocations
-                    `catchError` 
+                    `catchError`
                     goForLatestValid
 
-      where                       
+      where
 
-        useManifest mft childrenAki certLocations = do             
+        useManifest mft childrenAki certLocations = do
             validateManifestAndItsChildren mft childrenAki certLocations
                 `recover` do
                     -- manifest should be marked as visited regardless of its validitity
@@ -462,12 +446,12 @@ validateCaCertificate
                     cacheH2K topDownContext (getHash $ mft ^. #object) (mft ^. #key)
 
 
-        validateManifestAndItsChildren keyedMft childrenAki certLocations = do                         
+        validateManifestAndItsChildren keyedMft childrenAki certLocations = do
             let locatedMft = keyedMft ^. #object
-            let mft = locatedMft ^. #payload            
+            let mft = locatedMft ^. #payload
 
-            visitedObjects <- liftIO $ readTVarIO visitedHashes            
-            when (getHash mft `Set.member` visitedObjects) $                 
+            visitedObjects <- liftIO $ readTVarIO visitedHashes
+            when (getHash mft `Set.member` visitedObjects) $
                 -- We have already visited this manifest before, so 
                 -- there're some circular references in the objects.
                 -- 
@@ -484,25 +468,25 @@ validateCaCertificate
             validateMftLocation locatedMft certificate
 
             manifestResult <- inSubObjectVScope (locationsToText $ locatedMft ^. #locations) $ do
-                T2 _ crlHash <- 
-                    case findCrlOnMft mft of 
+                T2 _ crlHash <-
+                    case findCrlOnMft mft of
                         []    -> vError $ NoCRLOnMFT childrenAki certLocations
                         [crl] -> pure crl
                         crls  -> vError $ MoreThanOneCRLOnMFT childrenAki certLocations crls
 
-                crlKeyed <- liftIO $ do 
+                crlKeyed <- liftIO $ do
                         db <- readTVarIO database
                         roTx db $ \tx -> getKeyedByHash tx db crlHash
-                case crlKeyed of 
-                    Nothing -> 
-                        vError $ NoCRLExists childrenAki certLocations    
+                case crlKeyed of
+                    Nothing ->
+                        vError $ NoCRLExists childrenAki certLocations
 
-                    Just (Keyed foundCrl@(Located crlLocations (CrlRO crl)) crlKey) -> do      
-                        visitObject topDownContext foundCrl       
-                        cacheH2K topDownContext (getHash crl) crlKey                 
+                    Just (Keyed foundCrl@(Located crlLocations (CrlRO crl)) crlKey) -> do
+                        visitObject topDownContext foundCrl
+                        cacheH2K topDownContext (getHash crl) crlKey
                         validateObjectLocations foundCrl
-                        validCrl <- inSubObjectVScope (locationsToText crlLocations) $ 
-                                        vHoist $ do        
+                        validCrl <- inSubObjectVScope (locationsToText crlLocations) $
+                                        vHoist $ do
                                             let mftEECert = getEECert $ unCMS $ cmsPayload mft
                                             checkCrlLocation foundCrl mftEECert
                                             validateCrl now crl certificate
@@ -510,9 +494,9 @@ validateCaCertificate
 
                         -- MFT can be revoked by the CRL that is on this MFT -- detect 
                         -- revocation as well                               
-                        void $ vHoist $ validateMft now mft 
+                        void $ vHoist $ validateMft now mft
                                             certificate validCrl verifiedResources
-                                            
+
                         -- Validate entry list and filter out CRL itself
                         nonCrlChildren <- validateMftEntries mft (getHash crl)
 
@@ -520,13 +504,13 @@ validateCaCertificate
                         -- when some of the children are garbage-collected from the cache 
                         -- and some are still there. Do it both in case of successful 
                         -- validation or a validation error.
-                        let markAllEntriesAsVisited = 
-                                visitObjects topDownContext $ map (\(T2 _ h) -> h) nonCrlChildren                                
-                                                
-                        let processChildren = do 
+                        let markAllEntriesAsVisited =
+                                visitObjects topDownContext $ map (\(T2 _ h) -> h) nonCrlChildren
+
+                        let processChildren = do
                                 -- this indicates the difeerence between RFC9286-bis 
                                 -- version 02 (strict) and version 03 and later (more loose).                                                                                            
-                                let gatherMftEntryValidations = 
+                                let gatherMftEntryValidations =
                                         case config ^. #validationConfig . #manifestProcessing of
                                             {-                                             
                                             https://datatracker.ietf.org/doc/rfc9286/
@@ -551,47 +535,47 @@ validateCaCertificate
                                             -}
                                             RFC6486_Strict -> allOrNothingMftChildrenResults
 
-                                gatherMftEntryResults =<< gatherMftEntryValidations nonCrlChildren validCrl                                                                       
+                                gatherMftEntryResults =<< gatherMftEntryValidations nonCrlChildren validCrl
 
-                        foldr (<>) mempty <$> processChildren `recover` markAllEntriesAsVisited                                                
+                        foldr (<>) mempty <$> processChildren `recover` markAllEntriesAsVisited
 
-                    Just _ -> 
-                        vError $ CRLHashPointsToAnotherObject crlHash certLocations   
+                    Just _ ->
+                        vError $ CRLHashPointsToAnotherObject crlHash certLocations
 
             oneMoreMft
             addValidMft topDownContext childrenAki (keyedMft ^. #key)
-            pure manifestResult            
+            pure manifestResult
 
     allOrNothingMftChildrenResults nonCrlChildren validCrl = do
         vp <- askScopes
         liftIO $ pooledForConcurrently
             nonCrlChildren
-            $ \(T2 filename hash') -> runValidatorT vp $ do 
-                    ro <- findManifestEntryObject filename hash' 
+            $ \(T2 filename hash') -> runValidatorT vp $ do
+                    ro <- findManifestEntryObject filename hash'
                     -- if failed this one interrupts the whole MFT valdiation
-                    validateMftChild ro filename validCrl                
+                    validateMftChild ro filename validCrl
 
     independentMftChildrenResults nonCrlChildren validCrl = do
         vp <- askScopes
         liftIO $ pooledForConcurrently
             nonCrlChildren
-            $ \(T2 filename hash') -> do 
-                (r, vs) <- runValidatorT vp $ findManifestEntryObject filename hash' 
-                case r of 
+            $ \(T2 filename hash') -> do
+                (r, vs) <- runValidatorT vp $ findManifestEntryObject filename hash'
+                case r of
                     Left e   -> pure (Left e, vs)
-                    Right ro -> do 
+                    Right ro -> do
                         -- We are cheating here a little by faking the empty VRP set.
                         -- 
                         -- if failed, this one will result in the empty VRP set
                         -- while keeping errors and warning in the `vs'` value.
                         (z, vs') <- runValidatorT vp $ validateMftChild ro filename validCrl
-                        pure $ case z of                             
+                        pure $ case z of
                             Left _ -> (Right mempty, vs')
-                            _      -> (z, vs')     
+                            _      -> (z, vs')
 
-    gatherMftEntryResults mftEntryResults = do                 
+    gatherMftEntryResults mftEntryResults = do
         -- gather all the validation states from every MFT entry
-        mapM_ (embedState . snd) mftEntryResults                
+        mapM_ (embedState . snd) mftEntryResults
 
         case partitionEithers $ map fst mftEntryResults of
             ([], payloads) -> pure payloads
@@ -599,20 +583,20 @@ validateCaCertificate
 
     -- Check manifest entries as a whole, without doing anything 
     -- with the objects they are pointing to.    
-    validateMftEntries mft crlHash = do         
+    validateMftEntries mft crlHash = do
         let mftChildren = mftEntries $ getCMSContent $ cmsPayload mft
-        when (null mftChildren) $ 
+        when (null mftChildren) $
             vError ZeroManifestEntries
 
         let nonCrlChildren = filter (\(T2 _ hash') -> crlHash /= hash') mftChildren
-                    
+
         -- Make sure all the entries are unique
         let entryMap = Map.fromListWith (<>) $ map (\(T2 f h) -> (h, [f])) nonCrlChildren
         let nonUniqueEntries = Map.filter longerThanOne entryMap
 
         -- Don't crash here, it's just a warning, at the moment RFC doesn't say anything 
         -- about uniqueness of manifest entries.
-        unless (Map.null nonUniqueEntries) $ 
+        unless (Map.null nonUniqueEntries) $
             vWarn $ NonUniqueManifestEntries $ Map.toList nonUniqueEntries
 
         pure nonCrlChildren
@@ -622,21 +606,21 @@ validateCaCertificate
             longerThanOne _   = True
 
     getManifestEntry hash' filename = do
-        ro <- liftIO $ do 
+        ro <- liftIO $ do
             db <- readTVarIO database
             roTx db $ \tx -> getKeyedByHash tx db hash'
-        case ro of 
+        case ro of
             Nothing  -> vError $ ManifestEntryDoesn'tExist hash' filename
-            Just (Keyed object key) -> do 
+            Just (Keyed object key) -> do
                 cacheH2K topDownContext (getHash object) key
-                pure object        
+                pure object
 
-    findManifestEntryObject filename hash' = do                    
-        validateMftFileName filename        
+    findManifestEntryObject filename hash' = do
+        validateMftFileName filename
         db    <- liftIO $ readTVarIO database
         brief <- liftIO $ roTx db $ \tx -> getOjectBrief tx db hash'
-        case brief of 
-            Just b -> do 
+        case brief of
+            Just b -> do
                 cacheH2K topDownContext hash' (b ^. #key)
                 pure $! RBrief (b ^. #object) hash'
             Nothing -> RObject <$> getManifestEntry hash' filename
@@ -644,40 +628,40 @@ validateCaCertificate
 
     validateMftChild child filename validCrl = do
         -- warn about names on the manifest mismatching names in the object URLs
-        let objectLocations = case child of 
+        let objectLocations = case child of
                 RObject o  -> getLocations o
                 RBrief o _ -> getLocations o
 
         let nameMatches = NESet.filter ((filename `Text.isSuffixOf`) . toText) $ unLocations objectLocations
-        when (null nameMatches) $ 
+        when (null nameMatches) $
             vWarn $ ManifestLocationMismatch filename objectLocations
 
-        case child of             
-            RBrief ((^. #payload) -> brief) h                
+        case child of
+            RBrief ((^. #payload) -> brief) h
                 | getHash certificate == brief ^. #parentHash ->
                     -- It's under the same parent, so it's definitely the same object.
                     validateBrief brief validCrl
-                | otherwise -> do 
+                | otherwise -> do
                     -- oops, brief is not as we expected it to be, switch to the real object
                     me <- getManifestEntry h filename
                     validateRealObject me validCrl
-            RObject o -> 
+            RObject o ->
                 validateRealObject o validCrl
 
     {- 
         There's a brief for the already validated object, so only check, 
         validity period and if it wasn't revoked.             
-    -}    
+    -}
     validateBrief brief validCrl = do
         vHoist $ do
-            validateCertValidityPeriod brief now        
+            validateCertValidityPeriod brief now
             if (isRevoked brief validCrl) then do
                 void $ vPureWarning RevokedResourceCertificate
                 pure $! mempty
-            else do 
+            else do
                 oneMoreBrief
-                case brief ^. #briefType of 
-                    RoaBrief  -> do 
+                case brief ^. #briefType of
+                    RoaBrief  -> do
                         oneMoreRoa
                         moreVrps $ Count $ fromIntegral $ Set.size $ brief ^. #payload . #vrps
                     AspaBrief -> oneMoreAspa
@@ -688,45 +672,45 @@ validateCaCertificate
     {-         
         Validate manifest children according to 
         https://datatracker.ietf.org/doc/rfc9286/
-    -}                    
-    validateRealObject child validCrl = do        
+    -}
+    validateRealObject child validCrl = do
         let locations = getLocations child
         case child ^. #payload of
-            CerRO childCert -> do 
+            CerRO childCert -> do
                 parentContext <- ask
                 {- 
                     Note that recursive validation of the child CA happens in the separate   
                     runValidatorT (...) call, it is to avoid short-circuit logic implemented by ExceptT.
                     It is done to prevent child CAs short-circuiting and breaking validation of parents.
-                -}                
-                (r, validationState) <- liftIO $ runValidatorT parentContext $                     
+                -}
+                (r, validationState) <- liftIO $ runValidatorT parentContext $
                         inSubObjectVScope (toText $ pickLocation locations) $ do
-                            childVerifiedResources <- vHoist $ do                 
-                                    Validated validCert <- validateResourceCert @_ @_ @'CACert 
+                            childVerifiedResources <- vHoist $ do
+                                    Validated validCert <- validateResourceCert @_ @_ @'CACert
                                             now childCert (certificate ^. #payload) validCrl
                                     validateResources verifiedResources childCert validCert
-                            let childTopDownContext = topDownContext 
-                                    & #verifiedResources ?~ childVerifiedResources  
-                                    & #currentPathDepth %~ (+ 1)                            
-                            validateCaCertificate appContext childTopDownContext (Located locations childCert)                            
+                            let childTopDownContext = topDownContext
+                                    & #verifiedResources ?~ childVerifiedResources
+                                    & #currentPathDepth %~ (+ 1)
+                            validateCa appContext childTopDownContext (Located locations childCert)
 
                 embedState validationState
-                pure $! fromRight mempty r                
+                pure $! fromRight mempty r
 
-            RoaRO roa -> do 
+            RoaRO roa -> do
                 validateObjectLocations child
-                inSubObjectVScope (locationsToText locations) $ 
+                inSubObjectVScope (locationsToText locations) $
                     allowRevoked $ do
                         void $ vHoist $ validateRoa now roa certificate validCrl verifiedResources
-                        let vrpList = getCMSContent $ cmsPayload roa                            
-                        oneMoreRoa                            
+                        let vrpList = getCMSContent $ cmsPayload roa
+                        oneMoreRoa
                         moreVrps $ Count $ fromIntegral $ length vrpList
                         let payload = (mempty :: Payloads (Set Vrp)) { vrps = Set.fromList vrpList }
-                        updateEEBrief roa RoaBrief payload                        
+                        updateEEBrief roa RoaBrief payload
 
-            GbrRO gbr -> do                
+            GbrRO gbr -> do
                 validateObjectLocations child
-                inSubObjectVScope (locationsToText locations) $ 
+                inSubObjectVScope (locationsToText locations) $
                     allowRevoked $ do
                         void $ vHoist $ validateGbr now gbr certificate validCrl verifiedResources
                         oneMoreGbr
@@ -734,37 +718,37 @@ validateCaCertificate
                         let payload = (mempty :: Payloads (Set Vrp)) { gbrs = Set.singleton (getHash gbr, gbr') }
                         pure $! Seq.singleton $ payload
 
-            AspaRO aspa -> do                
+            AspaRO aspa -> do
                 validateObjectLocations child
-                inSubObjectVScope (locationsToText locations) $ 
+                inSubObjectVScope (locationsToText locations) $
                     allowRevoked $ do
                         void $ vHoist $ validateAspa now aspa certificate validCrl verifiedResources
-                        oneMoreAspa            
+                        oneMoreAspa
                         let aspa' = getCMSContent $ cmsPayload aspa
                         let payload = (mempty :: Payloads (Set Vrp)) { aspas = Set.singleton aspa' }
-                        updateEEBrief aspa AspaBrief payload                        
+                        updateEEBrief aspa AspaBrief payload
 
-            BgpRO bgpCert -> do                
+            BgpRO bgpCert -> do
                 validateObjectLocations child
-                inSubObjectVScope (locationsToText locations) $ 
+                inSubObjectVScope (locationsToText locations) $
                     allowRevoked $ do
                         bgpPayload <- vHoist $ validateBgpCert now bgpCert certificate validCrl
                         oneMoreBgp
                         let payload = (mempty :: Payloads (Set Vrp)) { bgpCerts = Set.singleton bgpPayload }
-                        updateEEBrief bgpCert BgpBrief payload                        
-                            
+                        updateEEBrief bgpCert BgpBrief payload
+
 
             -- Any new type of object should be added here, otherwise
             -- they will emit a warning.
-            _somethingElse -> do 
+            _somethingElse -> do
                 logWarn logger [i|Unsupported type of object: #{locations}.|]
                 pure $! Seq.singleton mempty
 
-        where                
-              
-            updateEEBrief :: (MonadIO m, WithHash object, WithValidityPeriod object, WithSerial object) => 
+        where
+
+            updateEEBrief :: (MonadIO m, WithHash object, WithValidityPeriod object, WithSerial object) =>
                             object -> BriefType -> Payloads (Set.Set Vrp) -> m (Seq (Payloads (Set Vrp)))
-            updateEEBrief object briefType payload = liftIO $ do 
+            updateEEBrief object briefType payload = liftIO $ do
                 let (notValidBefore, notValidAfter) = getValidityPeriod object
                 let parentHash = getHash certificate
                 let serial = getSerial object
@@ -777,14 +761,14 @@ validateCaCertificate
             -- Replace RevokedResourceCertificate error with a warmning and don't break the 
             -- validation process.            
             -- This is a slightly ad-hoc code, but works fine.
-            allowRevoked f =                
-                catchAndEraseError f isRevokedCertError $ do 
+            allowRevoked f =
+                catchAndEraseError f isRevokedCertError $ do
                     vWarn RevokedResourceCertificate
                     pure mempty
-                where                 
+                where
                     isRevokedCertError (ValidationE RevokedResourceCertificate) = True
                     isRevokedCertError _ = False
-   
+
 
 -- Mark validated objects in the database, i.e.
 -- 
@@ -792,64 +776,64 @@ validateCaCertificate
 -- - save all the valid manifests for each CA/AKI
 -- - save all the object validation briefs
 -- 
-applyValidationSideEffects :: (MonadIO m, Storage s) => 
+applyValidationSideEffects :: (MonadIO m, Storage s) =>
                              AppContext s -> AllTasTopDownContext -> m ()
-applyValidationSideEffects 
-    AppContext {..} 
+applyValidationSideEffects
+    AppContext {..}
     AllTasTopDownContext {..} = liftIO $ do
-    ((visitedSize, validMftsSize, briefNumber), elapsed) <- timedMS $ do 
-            (vhs, h2k, vmfts, briefs', db) <- atomically $ (,,,,) <$> 
-                                readTVar visitedHashes <*> 
-                                readTVar hash2Key <*> 
+    ((visitedSize, validMftsSize, briefNumber), elapsed) <- timedMS $ do
+            (vhs, h2k, vmfts, briefs', db) <- atomically $ (,,,,) <$>
+                                readTVar visitedHashes <*>
+                                readTVar hash2Key <*>
                                 readTVar validManifests <*>
                                 readTVar briefs <*>
                                 readTVar database
 
             briefCounter <- newIORef (0 :: Integer)
-            rwTx db $ \tx -> do 
-                markAsValidated tx db vhs h2k worldVersion 
+            rwTx db $ \tx -> do
+                markAsValidated tx db vhs h2k worldVersion
                 saveLatestValidMfts tx db (vmfts ^. #valids)
-                for_ briefs' $ \(BriefUpdate h brief) -> do 
+                for_ briefs' $ \(BriefUpdate h brief) -> do
                     saveObjectBrief tx db h brief
-                    modifyIORef' briefCounter (+1)                    
+                    modifyIORef' briefCounter (+1)
 
             c <- readIORef briefCounter
             pure (Set.size vhs, Map.size (vmfts ^. #valids), c)
 
     logInfo logger $
-        [i|Marked #{visitedSize} objects as used, #{validMftsSize} manifests as valid, |] <> 
+        [i|Marked #{visitedSize} objects as used, #{validMftsSize} manifests as valid, |] <>
         [i|saved #{briefNumber} brief objects, took #{elapsed}ms.|]
 
-    
+
 
 -- Do whatever is required to notify other subsystems that the object was touched 
 -- during top-down validation. It doesn't mean that the object is valid, just that 
 -- we read it from the database and looked at it. It will be used to decide when 
 -- to GC this object from the cache -- if it's not visited for too long, it is 
 -- removed.
-visitObject :: (MonadIO m, WithHash ro) => 
+visitObject :: (MonadIO m, WithHash ro) =>
                 TopDownContext -> ro -> m ()
-visitObject topDownContext ro = 
-    visitObjects topDownContext [getHash ro]    
+visitObject topDownContext ro =
+    visitObjects topDownContext [getHash ro]
 
 visitObjects :: MonadIO m => TopDownContext -> [Hash] -> m ()
 visitObjects TopDownContext { allTas = AllTasTopDownContext {..} } hashes =
-    liftIO $ atomically $ modifyTVar' visitedHashes (<> Set.fromList hashes)    
+    liftIO $ atomically $ modifyTVar' visitedHashes (<> Set.fromList hashes)
 
 -- Add manifest to the map of the valid ones
 addValidMft :: MonadIO m => TopDownContext -> AKI -> ObjectKey -> m ()
-addValidMft TopDownContext { allTas = AllTasTopDownContext {..}} aki mftKey = 
-    liftIO $ atomically $ modifyTVar' 
+addValidMft TopDownContext { allTas = AllTasTopDownContext {..}} aki mftKey =
+    liftIO $ atomically $ modifyTVar'
                 validManifests (& #valids %~ Map.insert aki mftKey)
-                
+
 -- Cache hash-to-objectKey mapping to speed up getting object key 
 -- by hash. It is done to save some extra 100-150ms of CPU time 
 -- of fetching this information from the database.
 -- 
 cacheH2K :: MonadIO m => TopDownContext -> Hash -> ObjectKey -> m ()
-cacheH2K TopDownContext { allTas = AllTasTopDownContext {..}} hash key = 
+cacheH2K TopDownContext { allTas = AllTasTopDownContext {..}} hash key =
     liftIO $ atomically $ modifyTVar' hash2Key $ Map.insert hash key
-                
+
 
 oneMoreCert, oneMoreRoa, oneMoreMft, oneMoreCrl :: Monad m => ValidatorT m ()
 oneMoreGbr, oneMoreAspa, oneMoreBgp, oneMoreBrief :: Monad m => ValidatorT m ()
@@ -869,9 +853,9 @@ moreVrps n = updateMetric @ValidationMetric @_ (& #vrpCounter %~ (+n))
 -- Number of unique VRPs requires explicit counting of the VRP set sizes, 
 -- so just counting the number of VRPs in ROAs in not enough
 addUniqueVRPCount :: (HasType ValidationState s, HasField' "payloads" s (Payloads Vrps)) => s -> s
-addUniqueVRPCount s = let 
+addUniqueVRPCount s = let
         vrpCountLens = typed @ValidationState . typed @RawMetric . #vrpCounts
-    in s & vrpCountLens . #totalUnique .~ 
+    in s & vrpCountLens . #totalUnique .~
                 Count (fromIntegral $ uniqueVrpCount $ (s ^. #payloads) ^. #vrps)
          & vrpCountLens . #perTaUnique .~
-                MonoidalMap.map (Count . fromIntegral . Set.size) (unVrps $ (s ^. #payloads) ^. #vrps)    
+                MonoidalMap.map (Count . fromIntegral . Set.size) (unVrps $ (s ^. #payloads) ^. #vrps)   

--- a/src/RPKI/Validation/TopDown.hs
+++ b/src/RPKI/Validation/TopDown.hs
@@ -842,6 +842,10 @@ addValidMft TopDownContext { allTas = AllTasTopDownContext {..}} aki mftKey =
     liftIO $ atomically $ modifyTVar' 
                 validManifests (& #valids %~ Map.insert aki mftKey)
                 
+-- Cache hash-to-objectKey mapping to speed up getting object key 
+-- by hash. It is done to save some extra 100-150ms of CPU time 
+-- of fetching this information from the database.
+-- 
 cacheH2K :: MonadIO m => TopDownContext -> Hash -> ObjectKey -> m ()
 cacheH2K TopDownContext { allTas = AllTasTopDownContext {..}} hash key = 
     liftIO $ atomically $ modifyTVar' hash2Key $ Map.insert hash key

--- a/src/RPKI/Validation/TopDown.hs
+++ b/src/RPKI/Validation/TopDown.hs
@@ -266,7 +266,7 @@ validateTACertificateFromTAL appContext@AppContext {..} tal worldVersion = do
             Left e         -> appError $ ValidationE e
             Right ppAccess -> 
                 rwAppTxEx taStore storageError $ \tx -> do 
-                    putTA tx taStore (StorableTA tal actualCert (FetchedAt moment) ppAccess)
+                    saveTA tx taStore (StorableTA tal actualCert (FetchedAt moment) ppAccess)
                     pure (locatedTaCert uri' actualCert, ppAccess, Updated)
             
     locatedTaCert url cert = Located (toLocations url) cert
@@ -794,14 +794,10 @@ applyValidationSideEffects
 
             briefCounter <- newIORef (0 :: Integer)
             zz <- rwTx db $ \tx -> do 
-                    zz <- markValidated1 tx db vhs worldVersion 
-                    -- for_ vhs $ \h -> 
-                    --     markValidated tx db h worldVersion 
+                    zz <- markAsValidated tx db vhs worldVersion 
                     saveLatestValidMfts tx db (vmfts ^. #valids)
-                    -- for_ (Map.toList vmfts) $ \(aki, h) -> 
-                    --     markLatestValidMft tx db aki h                
                     for_ briefs' $ \(BriefUpdate h brief) -> do 
-                        putObjectBrief tx db h brief
+                        saveObjectBrief tx db h brief
                         modifyIORef' briefCounter (+1)
                     pure zz
 

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -45,6 +45,7 @@ import           RPKI.Time
 import           RPKI.Util (fmtEx, trimmed)
 import           RPKI.SLURM.Types
 import           RPKI.Store.Base.Serialisation
+import           RPKI.Store.Database
 
 
 {- | This is to run worker processes for some code that is better to be executed in an isolated process.
@@ -87,7 +88,10 @@ data WorkerParams = RrdpFetchParams {
             ValidationParams {                 
                 worldVersion :: WorldVersion,
                 tals         :: [TAL]
-            } 
+            } | 
+            CacheCleanupParams { 
+                worldVersion :: WorldVersion
+            }
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (TheBinary)
 
@@ -120,6 +124,10 @@ newtype CompactionResult = CompactionResult ()
     deriving anyclass (TheBinary)
 
 data ValidationResult = ValidationResult ValidationState (Maybe Slurm)
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (TheBinary)
+
+data CacheCleanupResult = CacheCleanupResult CleanUpResult
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (TheBinary)
 

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -133,7 +133,7 @@ data CacheCleanupResult = CacheCleanupResult CleanUpResult
 
 
 data WorkerResult r = WorkerResult {
-        payload   :: r,
+        payload   :: r,        
         cpuTime   :: CPUTime,
         clockTime :: TimeMs,
         maxMemory :: MaxMemory
@@ -298,3 +298,8 @@ runWorker logger config workerId params timeout extraCli = do
     complain message = do 
         logError logger message
         appError $ InternalE $ InternalError message
+
+logWorkerDone :: (Logger logger, MonadIO m) =>
+                logger -> WorkerId -> WorkerResult r -> m ()
+logWorkerDone logger workerId WorkerResult {..} =     
+    logDebug logger [i|Worker '#{workerId}' finished, cpuTime: #{cpuTime}ms, clockTime: #{clockTime}ms, maxMemory: #{maxMemory}.|]

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -377,7 +377,7 @@ runValidation appContext@AppContext {..} worldVersion tals = do
 
     -- Save all the results into LMDB
     let updatedValidation = slurmValidations <> topDownValidations ^. typed
-    rwTx database' $ \tx -> do
+    (_, elapsed) <- timedMS $ rwTx database' $ \tx -> do
         putValidations tx database' worldVersion (updatedValidation ^. typed)
         putMetrics tx database' worldVersion (topDownValidations ^. typed)
         putVrps tx database' (payloads ^. #vrps) worldVersion
@@ -386,6 +386,8 @@ runValidation appContext@AppContext {..} worldVersion tals = do
         putBgps tx database' (payloads ^. #bgpCerts) worldVersion
         for_ maybeSlurm $ putSlurm tx database' worldVersion
         completeWorldVersion tx database' worldVersion
+
+    logDebug logger [i|Saved payloads for the version #{worldVersion} in #{elapsed}ms.|]    
 
     pure (topDownValidations, maybeSlurm)
 

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -404,7 +404,7 @@ runValidation appContext@AppContext {..} worldVersion tals = do
         completeWorldVersion tx db worldVersion
 
     logDebug logger [i|Saved payloads for the version #{worldVersion} in #{elapsed}ms.|]    
-    threadDelay 30_000_000
+    -- threadDelay 30_000_000
 
     pure (updatedValidation, maybeSlurm)
 

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -232,7 +232,7 @@ runWorkflow appContext@AppContext {..} tals = do
                         pushSystem logger $ cpuMemMetric "cache-clean-up" cpuTime maxMemory
                         pure $ Right payload                                       
 
-        -- Delete oldest world versions and all the data related to them.
+        -- Delete oldest payloads, e.g. VRPs, ASPAs, validation results, etc.
         cleanOldPayloads sharedBetweenJobs worldVersion _ = do
             let now = versionToMoment worldVersion
             db <- readTVarIO database
@@ -243,7 +243,7 @@ runWorkflow appContext@AppContext {..} tals = do
                         atomically $ modifyTVar' sharedBetweenJobs (#deletedAnythingFromDb .~ True)                        
                         logInfo logger [i|Done with deleting older versions, deleted #{deleted} versions, took #{elapsed}ms.|])
 
-        -- Do the custom LMDB compaction
+        -- Do the LMDB compaction
         compact sharedBetweenJobs worldVersion _ = do
             -- Some heuristics first to see if it's obvisouly too early to run compaction:
             -- if we have never deleted anything, there's no fragmentation, so no compaction needed.

--- a/test/src/RPKI/Orphans.hs
+++ b/test/src/RPKI/Orphans.hs
@@ -85,21 +85,30 @@ instance Arbitrary RrdpURL where
 instance Arbitrary RsyncURL where
     arbitrary = do
         ext  <- elements [ ".cer", ".mft", ".roa", ".crl" ]
-        host <- listOf1 $ elements $ ['a'..'z'] <> ['.']
+        hostName <- arbitrary 
         name <- listOf1 $ elements ['a'..'z']        
         name1 <- listOf1 $ elements ['a'..'z']        
         name2 <- listOf1 $ elements ['a'..'z']                
-        pure $ RsyncURL 
-                (RsyncHost $ convert host) 
+        pure $ RsyncURL hostName                
                 (Prelude.map (RsyncPathChunk . convert) [name1, name2, name <> ext])
     shrink = genericShrink
 
 instance Arbitrary RsyncHost where
-    arbitrary = fmap (RsyncHost . convert) $ listOf1 $ elements $ ['a'..'z']
+    arbitrary = RsyncHost <$> arbitrary <*> arbitrary
+    shrink = genericShrink
+
+instance Arbitrary RsyncHostName where
+    arbitrary = fmap (RsyncHostName . convert) $ listOf1 $ elements $ ['a'..'z'] <> ['.']
+    shrink = genericShrink
+
+instance Arbitrary RsyncPort where
+    arbitrary = do 
+        i <- arbitrary
+        pure $ RsyncPort $ 1024 + abs i `mod` 64000
     shrink = genericShrink
 
 instance Arbitrary RsyncPathChunk where
-    arbitrary = fmap (RsyncPathChunk . convert) $ listOf1 $ elements $ ['a'..'z']
+    arbitrary = fmap (RsyncPathChunk . convert) $ listOf1 $ elements ['a'..'z']
     shrink = genericShrink
 
 instance Arbitrary RpkiURL where

--- a/test/src/RPKI/RepositorySpec.hs
+++ b/test/src/RPKI/RepositorySpec.hs
@@ -107,6 +107,6 @@ generateRsyncUrl = do
     let level3 = replicate 10 Nothing <> map Just levelChunks
     host <- elements hosts
     pathLevels <- catMaybes <$> mapM elements [level1, level2, level3]
-    let rsyncHost = RsyncHost host
+    let rsyncHost = RsyncHost (RsyncHostName host) Nothing
     let path = map (RsyncPathChunk . convert) pathLevels
     pure $ RsyncURL rsyncHost path

--- a/test/src/RPKI/Store/DatabaseSpec.hs
+++ b/test/src/RPKI/Store/DatabaseSpec.hs
@@ -139,7 +139,7 @@ shouldMergeObjectLocations io = do
     verifyUrlCount objectStore "case 2" 3
 
     -- should only clean up URLs
-    CleanUpResult _ _ deletedUrls <- deleteStaleContent db (const True)
+    deletedUrls <- rwTx db $ deleteDanglingUrls db
     HU.assertEqual "Should have deleted 2 URLs" 2 deletedUrls
 
     verifyUrlCount objectStore "case 3" 1

--- a/test/src/RPKI/Store/DatabaseSpec.hs
+++ b/test/src/RPKI/Store/DatabaseSpec.hs
@@ -119,7 +119,6 @@ shouldMergeObjectLocations io = do
 
     let getIt hash = roTx objectStore $ \tx -> getByHash tx db hash    
 
-
     storeIt ro1 url1
     storeIt ro1 url2
     storeIt ro1 url3
@@ -132,17 +131,17 @@ shouldMergeObjectLocations io = do
     Just (Located loc2 _) <- getIt (getHash ro2)
     HU.assertEqual "Wrong locations 2" loc2 (toLocations url3)    
 
-    verifyUrlCount objectStore "1" 3    
+    verifyUrlCount objectStore "case 1" 3    
 
-    rwTx objectStore $ \tx ->
-        deleteObject tx db (getHash ro1)    
+    rwTx objectStore $ \tx -> deleteObject tx db (getHash ro1)    
 
-    verifyUrlCount objectStore "2" 3
+    verifyUrlCount objectStore "case 2" 3
 
     -- should only clean up URLs
-    cleanObjectCache db (const False)
+    deletedUrls <- deleteDanglinUrls db
+    HU.assertEqual "Should have deleted 2 URLs" 2 deletedUrls
 
-    verifyUrlCount objectStore "3" 1
+    verifyUrlCount objectStore "case 3" 1
 
     Just (Located loc2 _) <- getIt (getHash ro2)
     HU.assertEqual "Wrong locations 3" loc2 (toLocations url3)
@@ -261,7 +260,7 @@ shouldInsertAndGetAllBackFromValidationResultStore io = do
 
     world <- getOrCreateWorldVerion =<< newAppState
 
-    rwTx validationsStore $ \tx -> putValidations tx db world vrs
+    rwTx validationsStore $ \tx -> saveValidations tx db world vrs
     vrs' <- roTx validationsStore $ \tx -> validationsForVersion tx validationsStore world
 
     HU.assertEqual "Not the same Validations" (Just vrs) vrs'

--- a/test/src/RPKI/Store/DatabaseSpec.hs
+++ b/test/src/RPKI/Store/DatabaseSpec.hs
@@ -51,6 +51,7 @@ import qualified RPKI.Store.Base.MultiMap          as MM
 import           RPKI.Store.Base.Storable
 import           RPKI.Store.Base.Storage
 import           RPKI.Store.Database
+import           RPKI.Store.Types
 
 import qualified RPKI.Store.MakeLmdb as Lmdb
 
@@ -196,23 +197,23 @@ shouldInsertAndGetAllBackFromObjectStore io = do
             forM_ locations $ \url -> 
                 linkObjectToUrl tx objectStore url (getHash ro)
 
-    allObjects <- roTx objectStore $ \tx -> getAll tx objectStore
+    allObjects <- roTx objectStore $ \tx -> getAll tx db
     HU.assertEqual 
         "Not the same objects" 
         (List.sortOn (getHash . (^. #payload)) allObjects) 
         (List.sortOn (getHash . (^. #payload)) ros')
         
-    compareLatestMfts objectStore ros1 aki1    
-    compareLatestMfts objectStore ros2 aki2  
+    compareLatestMfts db ros1 aki1    
+    compareLatestMfts db ros2 aki2  
     
     let (toDelete, toKeep) = List.splitAt (List.length ros1 `div` 2) ros1
 
-    rwTx objectStore $ \tx -> 
+    rwTx db $ \tx -> 
         forM_ toDelete $ \(Located _ ro) -> 
             deleteObject tx db (getHash ro)
     
-    compareLatestMfts objectStore ros2 aki2      
-    compareLatestMfts objectStore toKeep aki1
+    compareLatestMfts db ros2 aki2      
+    compareLatestMfts db toKeep aki1
     
   where
     removeMftNumberDuplicates = List.nubBy $ \ro1 ro2 ->
@@ -228,12 +229,12 @@ shouldInsertAndGetAllBackFromObjectStore io = do
         let mftLatest' = listToMaybe $ List.sortOn (Down . getMftTimingMark)
                 [ mft | Located _ (MftRO mft) <- ros, getAKI mft == Just a ]                                    
         
-        HU.assertEqual "Not the same manifests" ((^. #payload) <$> mftLatest) mftLatest'                    
+        HU.assertEqual "Not the same manifests" ((^. #object . #payload) <$> mftLatest) mftLatest'                    
 
 
 shouldOrderManifests :: Storage s => IO (DB s) -> HU.Assertion
 shouldOrderManifests io = do  
-    DB {..} <- io
+    db@DB {..} <- io
     (Right (url1, mft1), _) <- runValidatorT (newScopes "read1") $ readObjectFromFile "./test/data/afrinic_mft1.mft"
     (Right (url2, mft2), _) <- runValidatorT (newScopes "read2") $ readObjectFromFile "./test/data/afrinic_mft2.mft"
 
@@ -248,7 +249,7 @@ shouldOrderManifests io = do
 
     -- they have the same AKIs
     let Just aki1 = getAKI mft1
-    Just (Located _ mftLatest) <- roTx objectStore $ \tx -> findLatestMftByAKI tx objectStore aki1
+    Just (Keyed (Located _ mftLatest) _) <- roTx objectStore $ \tx -> findLatestMftByAKI tx db aki1
 
     HU.assertEqual "Not the same manifests" (MftRO mftLatest) mft2
 

--- a/test/src/RPKI/Store/DatabaseSpec.hs
+++ b/test/src/RPKI/Store/DatabaseSpec.hs
@@ -139,7 +139,7 @@ shouldMergeObjectLocations io = do
     verifyUrlCount objectStore "case 2" 3
 
     -- should only clean up URLs
-    deletedUrls <- deleteDanglinUrls db
+    CleanUpResult _ _ deletedUrls <- deleteStaleContent db (const True)
     HU.assertEqual "Should have deleted 2 URLs" 2 deletedUrls
 
     verifyUrlCount objectStore "case 3" 1


### PR DESCRIPTION
After every validation, updating `lastValidatedBy` timestamps generates way to much disk writes.
This MR is to make the volume of writes an order of magnitude smaller.