### PR TITLE
Don't reject change because of bad objects

### DIFF
--- a/src/RPKI/RRDP/RrdpFetch.hs
+++ b/src/RPKI/RRDP/RrdpFetch.hs
@@ -432,10 +432,10 @@ saveSnapshot
                 inSubObjectVScope (unURI uri) $ appWarn e 
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logError logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e                 
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e                 
             ObjectParsingProblem rpkiUrl (VErr e) -> do                    
                 logError logger [i|Couldn't parse object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e                 
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e                 
             Success rpkiUrl so@StorableObject {..} -> do 
                 DB.putObject tx objectStore so worldVersion                    
                 DB.linkObjectToUrl tx objectStore rpkiUrl (getHash object)
@@ -551,10 +551,10 @@ saveDelta appContext worldVersion repoUri notification expectedSerial deltaConte
                 inSubObjectVScope (unURI uri) $ appWarn e 
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logError logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e                                     
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e                                     
             ObjectParsingProblem rpkiUrl (VErr e) -> do
                 logError logger [i|Couldn't parse object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e 
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e 
             Success rpkiUrl so@StorableObject {..} -> do 
                 let hash' = getHash object
                 alreadyThere <- DB.hashExists tx objectStore hash'
@@ -573,10 +573,10 @@ saveDelta appContext worldVersion repoUri notification expectedSerial deltaConte
                 inSubObjectVScope (unURI uri) $ appWarn e
             DecodingTrouble rpkiUrl (VErr e) -> do
                 logError logger [i|Couldn't decode base64 for object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e                                           
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e                                           
             ObjectParsingProblem rpkiUrl (VErr e) -> do
                 logError logger [i|Couldn't parse object #{uri}, error #{e} |]
-                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appError e 
+                inSubObjectVScope (unURI $ getURL rpkiUrl) $ appWarn e 
             Success rpkiUrl so@StorableObject {..} -> do 
                 oldOneIsAlreadyThere <- DB.hashExists tx objectStore oldHash                           
                 if oldOneIsAlreadyThere


### PR DESCRIPTION
Unparseable objects should not cause rejection of snapshot or even deltas. 
Complain and keep going, this will result in validation errors which is better 
than ignoring entire repository.