### PR TITLE
Fix premature worker timeouts

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -150,18 +150,22 @@ executeWorkerProcess = do
             case z of
                 Left e ->
                     logError logger [i|Couldn't initialise: #{e}, problems: #{validations}.|]
-                Right appContext ->                     
+                Right appContext ->                    
                     case input ^. #params of
                         RrdpFetchParams {..} -> exec resultHandler $
-                            fmap RrdpFetchResult $ runValidatorT scopes $ updateObjectForRrdpRepository
-                                appContext worldVersion rrdpRepository
+                            fmap RrdpFetchResult $ runValidatorT scopes $ 
+                                updateObjectForRrdpRepository appContext worldVersion rrdpRepository
+
                         RsyncFetchParams {..} -> exec resultHandler $
-                            fmap RsyncFetchResult $ runValidatorT scopes $ updateObjectForRsyncRepository
-                                appContext fetchConfig worldVersion rsyncRepository
+                            fmap RsyncFetchResult $ runValidatorT scopes $ 
+                                updateObjectForRsyncRepository appContext fetchConfig worldVersion rsyncRepository
+
                         CompactionParams {..} -> exec resultHandler $
                             CompactionResult <$> copyLmdbEnvironment appContext targetLmdbEnv
+
                         ValidationParams {..} -> exec resultHandler $
                             uncurry ValidationResult <$> runValidation appContext worldVersion tals
+
                         CacheCleanupParams {..} -> exec resultHandler $
                             CacheCleanupResult <$> runCacheCleanup appContext worldVersion
   where    

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Main where
 
@@ -142,15 +142,30 @@ executeWorkerProcess = do
                     
     -- turnOffTlsValidation
 
-    withLogger logConfig (\_ -> pure ()) $ \logger -> liftIO $ do
-        (z, validations) <- runValidatorT
-                                (newScopes "worker-create-app-context")
-                                (createWorkerAppContext config logger)
-        case z of
-            Left e ->
-                logError logger [i|Couldn't initialise: #{e}, problems: #{validations}.|]
-            Right appContext ->
-                executeWorker input appContext
+    executeWork input $ \_ resultHandler -> 
+        withLogger logConfig (\_ -> pure ()) $ \logger -> liftIO $ do
+            (z, validations) <- runValidatorT
+                                    (newScopes "worker-create-app-context")
+                                    (createWorkerAppContext config logger)
+            case z of
+                Left e ->
+                    logError logger [i|Couldn't initialise: #{e}, problems: #{validations}.|]
+                Right appContext ->                     
+                    case input ^. #params of
+                        RrdpFetchParams {..} -> exec resultHandler $
+                            fmap RrdpFetchResult $ runValidatorT scopes $ updateObjectForRrdpRepository
+                                appContext worldVersion rrdpRepository
+                        RsyncFetchParams {..} -> exec resultHandler $
+                            fmap RsyncFetchResult $ runValidatorT scopes $ updateObjectForRsyncRepository
+                                appContext fetchConfig worldVersion rsyncRepository
+                        CompactionParams {..} -> exec resultHandler $
+                            CompactionResult <$> copyLmdbEnvironment appContext targetLmdbEnv
+                        ValidationParams {..} -> exec resultHandler $
+                            uncurry ValidationResult <$> runValidation appContext worldVersion tals
+                        CacheCleanupParams {..} -> exec resultHandler $
+                            CacheCleanupResult <$> runCacheCleanup appContext worldVersion
+  where    
+    exec resultHandler f = resultHandler =<< execWithStats f                    
 
 
 turnOffTlsValidation = do 
@@ -456,29 +471,6 @@ rsyncPrefetches CLIOptions {..} = do
         case parseRsyncURL (convert u) of
             Left e         -> appError $ UnspecifiedE [i|Rsync URL #{u} is invalid|] (convert $ show e)
             Right rsyncURL -> pure rsyncURL
-
-
--- This is for worker processes.
-executeWorker :: WorkerInput
-            -> AppLmdbEnv
-            -> IO ()
-executeWorker input appContext =
-    executeWork input $ \_ resultHandler -> do
-        case input ^. #params of
-            RrdpFetchParams {..} -> exec resultHandler $
-                fmap RrdpFetchResult $ runValidatorT scopes $ updateObjectForRrdpRepository
-                    appContext worldVersion rrdpRepository
-            RsyncFetchParams {..} -> exec resultHandler $
-                fmap RsyncFetchResult $ runValidatorT scopes $ updateObjectForRsyncRepository
-                    appContext fetchConfig worldVersion rsyncRepository
-            CompactionParams {..} -> exec resultHandler $
-                CompactionResult <$> copyLmdbEnvironment appContext targetLmdbEnv
-            ValidationParams {..} -> exec resultHandler $
-                uncurry ValidationResult <$> runValidation appContext worldVersion tals
-            CacheCleanupParams {..} -> exec resultHandler $
-                CacheCleanupResult <$> runCacheCleanup appContext worldVersion
-  where
-    exec resultHandler f = resultHandler =<< execWithStats f
 
 
 createWorkerAppContext :: Config -> AppLogger -> ValidatorT IO AppLmdbEnv

--- a/src/RPKI/Logging.hs
+++ b/src/RPKI/Logging.hs
@@ -250,7 +250,7 @@ eol :: Char
 eol = '\n' 
 
 -- Read input stream and extract serialised log messages from it.
--- Messages are separated by the EOL character and start with `startMessageMark`.
+-- Messages are separated by the EOL character.
 sinkLog :: MonadIO m => AppLogger -> ConduitT C8.ByteString o m ()
 sinkLog logger = go mempty        
   where

--- a/src/RPKI/Orphans/Json.hs
+++ b/src/RPKI/Orphans/Json.hs
@@ -44,12 +44,10 @@ import HaskellWorks.Data.Network.Ip.Ip as Ips
 
 import           RPKI.AppTypes
 import           RPKI.Domain                 as Domain
-import           RPKI.RRDP.Types             (RrdpSerial)
 import           RPKI.Config
 
 import           RPKI.Logging
 import           RPKI.Reporting
-import           RPKI.Repository
 import           RPKI.RRDP.Types
 import           RPKI.Metrics.Metrics
 import           RPKI.Metrics.System

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -149,13 +149,13 @@ executeWork :: WorkerInput
             -> IO ()
 executeWork input actualWork = do         
     exitCode <- anyOf 
-                    ((actualWork input writeWorkerOutput >> exitSuccess) `onException` exitFailure)
+                    ((actualWork input writeWorkerOutput >> pure ExitSuccess) `onException` pure exitException)
                     (anyOf dieIfParentDies dieOfTiming)
     
     exitWith exitCode
   where        
     anyOf a b = either id id <$> race a b
-
+    
     -- Keep track of who's the current process parent: if it is not the same 
     -- as we started with then parent exited/is killed. Exit the worker as well,
     -- there's no point continuing.
@@ -223,6 +223,7 @@ defaultRts :: [String]
 defaultRts = [ "-I0" ]
 
 exitParentDied, exitTimeout, exitOutOfCpuTime, exitOutOfMemory, exitKillByTypedProcess :: ExitCode
+exitException    = ExitFailure 99
 exitParentDied   = ExitFailure 111
 exitTimeout      = ExitFailure 122
 exitOutOfCpuTime = ExitFailure 113

--- a/src/RPKI/Worker.hs
+++ b/src/RPKI/Worker.hs
@@ -149,8 +149,8 @@ executeWork :: WorkerInput
             -> IO ()
 executeWork input actualWork = do         
     exitCode <- anyOf 
-                    ((actualWork input writeWorkerOutput >> pure ExitSuccess) `onException` pure exitException)
-                    (anyOf dieIfParentDies dieOfTiming)
+        ((actualWork input writeWorkerOutput >> pure ExitSuccess) `onException` pure exitException)
+        (anyOf dieIfParentDies dieOfTiming)
     
     exitWith exitCode
   where        
@@ -222,7 +222,7 @@ rtsMemValue mb = show mb <> "m"
 defaultRts :: [String]
 defaultRts = [ "-I0" ]
 
-exitParentDied, exitTimeout, exitOutOfCpuTime, exitOutOfMemory, exitKillByTypedProcess :: ExitCode
+exitParentDied, exitTimeout, exitOutOfCpuTime, exitOutOfMemory, exitKillByTypedProcess, exitException :: ExitCode
 exitException    = ExitFailure 99
 exitParentDied   = ExitFailure 111
 exitTimeout      = ExitFailure 122

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.23
+resolver: lts-22.26
 
 packages:
 - .


### PR DESCRIPTION
Also fix the 
`Problem deserialising binary log message: [rpki-prover: forkOS_entry: interrupted], error: "Base64-encoded bytestring requires padding for \"Broken base64 input\"rpki-prover: forkOS_entry: interrupted".`