### PR TITLE
Optimise/diff payload storage

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -112,7 +112,7 @@ executeMainProcess cliOptions@CLIOptions{..} = do
                 for_ z $ mergeSystemMetrics sm
 
         withLogger logConfig bumpSysMetric $ \logger -> do
-            logDebug logger $ if once 
+            logInfo logger $ if once 
                     then [i|Starting #{rpkiProverVersion} in one-off mode.|]
                     else [i|Starting #{rpkiProverVersion} as a server.|]
             

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 cp package-template.yaml package.yaml
+if [[ $(uname -m) == 'arm64' ]]; then
+    EXTRA_LIBRARIES="--extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=/opt/homebrew/lib"
+fi
 stack test rpki-prover:lib rpki-prover:test:rpki-prover-test --stack-yaml=stack.yaml

--- a/src/RPKI/Domain.hs
+++ b/src/RPKI/Domain.hs
@@ -575,7 +575,7 @@ data BGPSecPayload = BGPSecPayload {
         bgpSecSki  :: SKI,
         bgpSecAsns :: [ASN],
         bgpSecSpki :: SPKI
-        -- TODO Possible store the hash of the original BGP certificate?
+        -- TODO Possibly store the hash of the original BGP certificate?
     } 
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary, NFData)

--- a/src/RPKI/RTR/RtrServer.hs
+++ b/src/RPKI/RTR/RtrServer.hs
@@ -175,11 +175,14 @@ runRtrServer appContext RtrConfig {..} = do
                     writeTChan updateBroadcastChan [TruePdu notifyPdu]
                     writeTVar lastTimeNotified $ Just now
         where
-          logDiff GenDiffs {..} = do 
-            
-            let diffText =
-                    [i|VRPs: added #{Set.size $ added vrpDiff}, deleted #{Set.size $ deleted vrpDiff}, |] <>
-                    [i|BGPSecs: added #{Set.size $ added bgpSecDiff}, deleted #{Set.size $ deleted bgpSecDiff}|] :: Text
+          logDiff GenDiffs {..} = do             
+            let vrpAdded   = vrpDiff ^. #added
+                vrpDeleted = vrpDiff ^. #deleted
+                bgpSecAdded   = bgpSecDiff ^. #added
+                bgpSecDeleted = bgpSecDiff ^. #deleted
+                diffText :: Text = 
+                    [i|VRPs: added #{Set.size vrpAdded}, deleted #{Set.size vrpDeleted}, |] <>
+                    [i|BGPSecs: added #{Set.size bgpSecAdded}, deleted #{Set.size bgpSecDeleted}|]
 
             logDebug logger [i|Generated new diff, #{diffText}.|]            
 

--- a/src/RPKI/Reporting.hs
+++ b/src/RPKI/Reporting.hs
@@ -244,7 +244,7 @@ newtype AppException = AppException AppError
 
 instance Exception AppException
 
-newtype Validations = Validations (Map VScope (Set VIssue))
+newtype Validations = Validations { unValidations :: Map VScope (Set VIssue) }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary, NFData)
     deriving newtype Monoid

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -904,7 +904,6 @@ deleteDanglingUrls DB { objectStore = RpkiObjectStore {..} } tx = do
                         else result)
             mempty
 
-
     forM_ urlsToDelete $ \(urlKey, url) -> do 
         M.delete tx uriKeyToUri urlKey
         M.delete tx uriToUriKey (makeSafeUrl url)           

--- a/src/RPKI/Store/Diff.hs
+++ b/src/RPKI/Store/Diff.hs
@@ -13,24 +13,12 @@ module RPKI.Store.Diff where
 import           Control.Lens
 
 import           Data.Generics.Product.Typed
-import           Data.Generics.Product.Fields
 
-import qualified Data.ByteString          as BS
-import qualified Data.ByteString.Short    as BSS
-import           Data.Monoid.Generic
+import           Data.Set                 (Set, (\\))
 import qualified Data.Set                 as Set
-import           Data.Tuple.Strict
-import           Data.Kind
-import           Data.Store               hiding (Size)
-
-import           GHC.Generics
-import           RPKI.TAL
-
-import           RPKI.Time                (Instant)
 
 import           RPKI.Reporting
 import           RPKI.Repository
-import           RPKI.AppTypes
 import           RPKI.Domain
 import           RPKI.Store.Types
 import           RPKI.Store.Base.Storable
@@ -42,39 +30,33 @@ diff :: FlatPayloads -> FlatPayloads -> PayloadsDiff
 diff before after = PayloadsDiff {
         roas  = roasDiff (before ^. typed) (after ^. typed),
         vrps  = vrpsDiff (before ^. typed) (after ^. typed),
-        spls  = splDiff (before ^. typed) (after ^. typed),
-        aspas = aspaDiff (before ^. typed) (after ^. typed),
-        gbrs  = gbrDiff (before ^. typed) (after ^. typed),
-        bgpCerts    = bgpCertsDiff (before ^. typed) (after ^. typed),
+        spls  = makeSetDiff (before ^. typed) (after ^. typed),
+        aspas = makeSetDiff (before ^. typed) (after ^. typed),
+        gbrs  = makeSetDiff (before ^. typed) (after ^. typed),
+        bgpCerts    = makeSetDiff (before ^. typed) (after ^. typed),
         validations = validationsDiff (before ^. typed) (after ^. typed),
         metrics     = metricsDiff (before ^. typed) (after ^. typed),
-        traces      = tracesDiff (before ^. typed) (after ^. typed)
+        traces      = makeSetDiff (before ^. typed) (after ^. typed)
     }
     
 
-roasDiff :: Roas -> Roas -> GeneralDiff Roas
-roasDiff = GeneralDiff
+roasDiff :: Roas -> Roas -> StoredDiff Roas
+roasDiff = StoredDiff
 
-vrpsDiff :: Vrps -> Vrps -> GeneralDiff Vrps
-vrpsDiff = GeneralDiff
+vrpsDiff :: Vrps -> Vrps -> StoredDiff Vrps
+vrpsDiff = StoredDiff
 
-aspaDiff :: Set.Set Aspa -> Set.Set Aspa -> GeneralDiff (Set.Set Aspa)
-aspaDiff = GeneralDiff
+validationsDiff :: Validations -> Validations -> StoredDiff Validations
+validationsDiff = StoredDiff
 
-splDiff :: Set.Set SplN -> Set.Set SplN -> GeneralDiff (Set.Set SplN)
-splDiff = GeneralDiff
+metricsDiff :: RawMetric -> RawMetric -> StoredDiff RawMetric
+metricsDiff = StoredDiff
 
-gbrDiff :: Set.Set (T2 Hash Gbr) -> Set.Set (T2 Hash Gbr) -> GeneralDiff (Set.Set (T2 Hash Gbr))
-gbrDiff = GeneralDiff
+makeSetDiff :: Ord a => Set a -> Set a -> StoredDiff (Set a)
+makeSetDiff before after = StoredDiff {
+        added   = after \\ before,
+        deleted = before \\ after
+    }     
 
-bgpCertsDiff :: Set.Set BGPSecPayload -> Set.Set BGPSecPayload -> GeneralDiff (Set.Set BGPSecPayload)
-bgpCertsDiff = GeneralDiff
-
-validationsDiff :: Validations -> Validations -> GeneralDiff Validations
-validationsDiff = GeneralDiff
-
-metricsDiff :: RawMetric -> RawMetric -> GeneralDiff RawMetric
-metricsDiff = GeneralDiff
-
-tracesDiff :: Set.Set Trace -> Set.Set Trace -> GeneralDiff (Set.Set Trace)
-tracesDiff = GeneralDiff
+applySetDiff :: Ord a => Set a -> StoredDiff (Set a) -> Set a 
+applySetDiff before diff = before \\ (diff ^. #deleted) <> (diff ^. #added)

--- a/src/RPKI/Store/Diff.hs
+++ b/src/RPKI/Store/Diff.hs
@@ -118,11 +118,11 @@ instance (Eq k, Ord k, Diffable v) => Diffable (MonoidalMap k v) where
 
 instance Diffable Roas where
     makeDiff (Roas before) (Roas after) = mapDiff Roas $ makeDiff before after                 
-    applyDiff (Roas before) diff =  Roas $ applyDiff before (mapDiff unRoas diff)                
+    applyDiff (Roas before) diff = Roas $ applyDiff before (mapDiff unRoas diff)                
 
 instance Diffable Vrps where
     makeDiff (Vrps before) (Vrps after) = mapDiff Vrps $ makeDiff before after                 
-    applyDiff (Vrps before) diff =  Vrps $ applyDiff before (mapDiff unVrps diff)                
+    applyDiff (Vrps before) diff = Vrps $ applyDiff before (mapDiff unVrps diff)                
 
 instance Diffable Validations where
     makeDiff _ _ = NoDiff

--- a/src/RPKI/Store/Diff.hs
+++ b/src/RPKI/Store/Diff.hs
@@ -11,52 +11,100 @@
 module RPKI.Store.Diff where
 
 import           Control.Lens
+import           Control.DeepSeq
 
 import           Data.Generics.Product.Typed
 
 import           Data.Set                 (Set, (\\))
 import qualified Data.Set                 as Set
+import           Data.Tuple.Strict
+
+import           GHC.Generics
 
 import           RPKI.Reporting
-import           RPKI.Repository
 import           RPKI.Domain
-import           RPKI.Store.Types
-import           RPKI.Store.Base.Storable
 import           RPKI.Store.Base.Serialisation
 
--- Fuctions for diff-based storage
+
+data FlatPayloads = FlatPayloads {
+        roas        :: Roas,
+        vrps        :: Vrps,
+        spls        :: Set.Set SplN,
+        aspas       :: Set.Set Aspa,
+        gbrs        :: Set.Set (T2 Hash Gbr),
+        bgpCerts    :: Set.Set BGPSecPayload,
+        validations :: Validations,
+        metrics     :: RawMetric,
+        traces      :: Set.Set Trace
+    }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)
+
+
+data PayloadsDiff = PayloadsDiff {
+        roas        :: StoredDiff Roas,
+        vrps        :: StoredDiff Vrps,
+        spls        :: StoredDiff (Set.Set SplN),
+        aspas       :: StoredDiff (Set.Set Aspa),
+        gbrs        :: StoredDiff (Set.Set (T2 Hash Gbr)),
+        bgpCerts    :: StoredDiff (Set.Set BGPSecPayload),
+        validations :: StoredDiff Validations,
+        metrics     :: StoredDiff RawMetric,
+        traces      :: StoredDiff (Set.Set Trace)
+    }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)
+
+
+data StoredDiff a = StoredDiff {
+        added   :: a,
+        deleted :: a
+    }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)        
+
+
+class Diffable a where
+    makeDiff  :: a -> a -> StoredDiff a
+    applyDiff :: a -> StoredDiff a -> a
+
+instance Ord a => Diffable (Set.Set a) where
+    makeDiff before after = StoredDiff {
+            added   = after \\ before,
+            deleted = before \\ after
+        }     
+    applyDiff before diff = 
+        before \\ (diff ^. #deleted) <> (diff ^. #added)
+
+instance Diffable Roas where
+    makeDiff (Roas before) (Roas after) = 
+        StoredDiff (Roas before) (Roas after)
+        
+    applyDiff before diff = before
+
+instance Diffable Vrps where
+    makeDiff = StoredDiff
+    applyDiff before diff = before
+
+instance Diffable Validations where
+    makeDiff = StoredDiff
+    applyDiff before diff = before
+
+instance Diffable RawMetric where
+    makeDiff = StoredDiff
+    applyDiff before diff = before
+        
 
 diff :: FlatPayloads -> FlatPayloads -> PayloadsDiff
 diff before after = PayloadsDiff {
-        roas  = roasDiff (before ^. typed) (after ^. typed),
-        vrps  = vrpsDiff (before ^. typed) (after ^. typed),
-        spls  = makeSetDiff (before ^. typed) (after ^. typed),
-        aspas = makeSetDiff (before ^. typed) (after ^. typed),
-        gbrs  = makeSetDiff (before ^. typed) (after ^. typed),
-        bgpCerts    = makeSetDiff (before ^. typed) (after ^. typed),
-        validations = validationsDiff (before ^. typed) (after ^. typed),
-        metrics     = metricsDiff (before ^. typed) (after ^. typed),
-        traces      = makeSetDiff (before ^. typed) (after ^. typed)
+        roas  = makeDiff (before ^. typed) (after ^. typed),
+        vrps  = makeDiff (before ^. typed) (after ^. typed),
+        spls  = makeDiff (before ^. typed) (after ^. typed),
+        aspas = makeDiff (before ^. typed) (after ^. typed),
+        gbrs  = makeDiff (before ^. typed) (after ^. typed),
+        bgpCerts    = makeDiff (before ^. typed) (after ^. typed),
+        validations = makeDiff (before ^. typed) (after ^. typed),
+        metrics     = makeDiff (before ^. typed) (after ^. typed),
+        traces      = makeDiff (before ^. typed) (after ^. typed)
     }
     
-
-roasDiff :: Roas -> Roas -> StoredDiff Roas
-roasDiff = StoredDiff
-
-vrpsDiff :: Vrps -> Vrps -> StoredDiff Vrps
-vrpsDiff = StoredDiff
-
-validationsDiff :: Validations -> Validations -> StoredDiff Validations
-validationsDiff = StoredDiff
-
-metricsDiff :: RawMetric -> RawMetric -> StoredDiff RawMetric
-metricsDiff = StoredDiff
-
-makeSetDiff :: Ord a => Set a -> Set a -> StoredDiff (Set a)
-makeSetDiff before after = StoredDiff {
-        added   = after \\ before,
-        deleted = before \\ after
-    }     
-
-applySetDiff :: Ord a => Set a -> StoredDiff (Set a) -> Set a 
-applySetDiff before diff = before \\ (diff ^. #deleted) <> (diff ^. #added)

--- a/src/RPKI/Store/Diff.hs
+++ b/src/RPKI/Store/Diff.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE StrictData            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedLabels      #-}
+
+module RPKI.Store.Diff where
+
+import           Control.Lens
+
+import           Data.Generics.Product.Typed
+import           Data.Generics.Product.Fields
+
+import qualified Data.ByteString          as BS
+import qualified Data.ByteString.Short    as BSS
+import           Data.Monoid.Generic
+import qualified Data.Set                 as Set
+import           Data.Tuple.Strict
+import           Data.Kind
+import           Data.Store               hiding (Size)
+
+import           GHC.Generics
+import           RPKI.TAL
+
+import           RPKI.Time                (Instant)
+
+import           RPKI.Reporting
+import           RPKI.Repository
+import           RPKI.AppTypes
+import           RPKI.Domain
+import           RPKI.Store.Types
+import           RPKI.Store.Base.Storable
+import           RPKI.Store.Base.Serialisation
+
+-- Fuctions for diff-based storage
+
+diff :: FlatPayloads -> FlatPayloads -> PayloadsDiff
+diff before after = PayloadsDiff {
+        roas  = roasDiff (before ^. typed) (after ^. typed),
+        vrps  = vrpsDiff (before ^. typed) (after ^. typed),
+        spls  = splDiff (before ^. typed) (after ^. typed),
+        aspas = aspaDiff (before ^. typed) (after ^. typed),
+        gbrs  = gbrDiff (before ^. typed) (after ^. typed),
+        bgpCerts    = bgpCertsDiff (before ^. typed) (after ^. typed),
+        validations = validationsDiff (before ^. typed) (after ^. typed),
+        metrics     = metricsDiff (before ^. typed) (after ^. typed),
+        traces      = tracesDiff (before ^. typed) (after ^. typed)
+    }
+    
+
+roasDiff :: Roas -> Roas -> GeneralDiff Roas
+roasDiff = GeneralDiff
+
+vrpsDiff :: Vrps -> Vrps -> GeneralDiff Vrps
+vrpsDiff = GeneralDiff
+
+aspaDiff :: Set.Set Aspa -> Set.Set Aspa -> GeneralDiff (Set.Set Aspa)
+aspaDiff = GeneralDiff
+
+splDiff :: Set.Set SplN -> Set.Set SplN -> GeneralDiff (Set.Set SplN)
+splDiff = GeneralDiff
+
+gbrDiff :: Set.Set (T2 Hash Gbr) -> Set.Set (T2 Hash Gbr) -> GeneralDiff (Set.Set (T2 Hash Gbr))
+gbrDiff = GeneralDiff
+
+bgpCertsDiff :: Set.Set BGPSecPayload -> Set.Set BGPSecPayload -> GeneralDiff (Set.Set BGPSecPayload)
+bgpCertsDiff = GeneralDiff
+
+validationsDiff :: Validations -> Validations -> GeneralDiff Validations
+validationsDiff = GeneralDiff
+
+metricsDiff :: RawMetric -> RawMetric -> GeneralDiff RawMetric
+metricsDiff = GeneralDiff
+
+tracesDiff :: Set.Set Trace -> Set.Set Trace -> GeneralDiff (Set.Set Trace)
+tracesDiff = GeneralDiff

--- a/src/RPKI/Store/MakeLmdb.hs
+++ b/src/RPKI/Store/MakeLmdb.hs
@@ -5,7 +5,7 @@
 
 module RPKI.Store.MakeLmdb where
 
-import Control.Lens
+import Control.Lens hiding (Empty)
 import Control.Concurrent.STM
 
 import           Data.IORef
@@ -77,7 +77,7 @@ createDatabase env logger checkAction = do
         aspaStore        <- AspaStore <$> createMap    
         gbrStore         <- GbrStore <$> createMap 
         bgpStore         <- BgpStore <$> createMap
-        versionStore     <- VersionStore <$> createMap
+        versionStore     <- createVersionStore
         metricStore      <- MetricStore <$> createMap
         slurmStore       <- SlurmStore <$> createMap
         jobStore         <- JobStore <$> createMap        
@@ -109,6 +109,9 @@ createDatabase env logger checkAction = do
         createRepositoryStore = 
             RepositoryStore <$> createMap <*> createMap <*> createMap
         
+        createVersionStore = 
+            VersionStore <$> createMap <*> newTVarIO EmptyVCache
+
         lmdb = LmdbStorage env
 
         createMap :: forall k v name . (KnownSymbol name) => IO (SMap name LmdbStorage k v)

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards       #-}
@@ -11,7 +12,9 @@ module RPKI.Store.Types where
 import           Control.DeepSeq
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Short    as BSS
-
+import           Data.Monoid.Generic
+import qualified Data.Set                 as Set
+import           Data.Tuple.Strict
 import           GHC.Generics
 import           RPKI.TAL
 
@@ -66,3 +69,24 @@ data TotalDBStats = TotalDBStats {
     total        :: SStats,
     fileStats    :: DBFileStats
 } deriving stock (Show, Eq, Generic)
+
+
+data StorablePayloads = StorablePayloads {
+        roas     :: Roas,
+        spls     :: Set.Set SplN,
+        aspas    :: Set.Set Aspa,
+        gbrs     :: Set.Set (T2 Hash Gbr),
+        bgpCerts :: Set.Set BGPSecPayload  
+    }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)
+    deriving Semigroup via GenericSemigroup StorablePayloads
+    deriving Monoid    via GenericMonoid StorablePayloads
+
+
+data PayloadDiff a = PayloadDiff {
+        added   :: a,
+        deleted :: a
+    }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)        

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -6,13 +6,16 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE StrictData            #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedLabels      #-}
 
 module RPKI.Store.Types where
 
+import           Control.Lens
 import           Control.DeepSeq
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Short    as BSS
 import           Data.Monoid.Generic
+import           Data.Set                 (Set, (\\))
 import qualified Data.Set                 as Set
 import           Data.Tuple.Strict
 import           Data.Kind
@@ -76,41 +79,3 @@ data TotalDBStats = TotalDBStats {
         fileStats    :: DBFileStats
     } 
     deriving stock (Show, Eq, Generic)
-
-
-data FlatPayloads = FlatPayloads {
-        roas        :: Roas,
-        vrps        :: Vrps,
-        spls        :: Set.Set SplN,
-        aspas       :: Set.Set Aspa,
-        gbrs        :: Set.Set (T2 Hash Gbr),
-        bgpCerts    :: Set.Set BGPSecPayload,
-        validations :: Validations,
-        metrics     :: RawMetric,
-        traces      :: Set.Set Trace
-    }
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (TheBinary, NFData)
-
-
-data PayloadsDiff = PayloadsDiff {
-        roas        :: StoredDiff Roas,
-        vrps        :: StoredDiff Vrps,
-        spls        :: StoredDiff (Set.Set SplN),
-        aspas       :: StoredDiff (Set.Set Aspa),
-        gbrs        :: StoredDiff (Set.Set (T2 Hash Gbr)),
-        bgpCerts    :: StoredDiff (Set.Set BGPSecPayload),
-        validations :: StoredDiff Validations,
-        metrics     :: StoredDiff RawMetric,
-        traces      :: StoredDiff (Set.Set Trace)
-    }
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (TheBinary, NFData)
-
-
-data StoredDiff a = StoredDiff {
-        added   :: a,
-        deleted :: a
-    }
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (TheBinary, NFData)        

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -76,10 +76,6 @@ data TotalDBStats = TotalDBStats {
     } 
     deriving stock (Show, Eq, Generic)
 
-newtype AsIs a = AsIs { unAsIs :: a }
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (TheBinary, NFData)
-
 
 data FlatPayloads = FlatPayloads {
         roas        :: Roas,

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -10,23 +10,14 @@
 
 module RPKI.Store.Types where
 
-import           Control.Lens
 import           Control.DeepSeq
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Short    as BSS
-import           Data.Monoid.Generic
-import           Data.Set                 (Set, (\\))
-import qualified Data.Set                 as Set
-import           Data.Tuple.Strict
-import           Data.Kind
-import           Data.Store               hiding (Size)
 
 import           GHC.Generics
 import           RPKI.TAL
 
 import           RPKI.Time                (Instant)
-
-import           RPKI.Reporting
 import           RPKI.Repository
 import           RPKI.AppTypes
 import           RPKI.Domain
@@ -67,6 +58,17 @@ data Keyed a = Keyed {
 newtype ObjectOriginal = ObjectOriginal BS.ByteString
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary, NFData)        
+
+data VersionContent = FullVersion | DiffVersion
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary, NFData)        
+
+data VersionMeta = VersionMeta {
+        versionKind    :: VersionKind,
+        versionContent :: VersionContent
+    }    
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (TheBinary)        
 
 data DBFileStats = DBFileStats {
         fileSize :: Size

--- a/src/RPKI/Store/Types.hs
+++ b/src/RPKI/Store/Types.hs
@@ -94,21 +94,21 @@ data FlatPayloads = FlatPayloads {
 
 
 data PayloadsDiff = PayloadsDiff {
-        roas        :: GeneralDiff Roas,
-        vrps        :: GeneralDiff Vrps,
-        spls        :: GeneralDiff (Set.Set SplN),
-        aspas       :: GeneralDiff (Set.Set Aspa),
-        gbrs        :: GeneralDiff (Set.Set (T2 Hash Gbr)),
-        bgpCerts    :: GeneralDiff (Set.Set BGPSecPayload),
-        validations :: GeneralDiff Validations,
-        metrics     :: GeneralDiff RawMetric,
-        traces      :: GeneralDiff (Set.Set Trace)
+        roas        :: StoredDiff Roas,
+        vrps        :: StoredDiff Vrps,
+        spls        :: StoredDiff (Set.Set SplN),
+        aspas       :: StoredDiff (Set.Set Aspa),
+        gbrs        :: StoredDiff (Set.Set (T2 Hash Gbr)),
+        bgpCerts    :: StoredDiff (Set.Set BGPSecPayload),
+        validations :: StoredDiff Validations,
+        metrics     :: StoredDiff RawMetric,
+        traces      :: StoredDiff (Set.Set Trace)
     }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (TheBinary, NFData)
 
 
-data GeneralDiff a = GeneralDiff {
+data StoredDiff a = StoredDiff {
         added   :: a,
         deleted :: a
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.33
+resolver: lts-22.35
 
 packages:
 - .

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import RPKI.Parse.ObjectParseSpec
 import RPKI.RRDP.ParseSpec
 import RPKI.Store.DatabaseSpec
+import RPKI.Store.DiffSpec
 import RPKI.RRDP.UpdateSpec
 import RPKI.RRDP.HttpSpec
 import RPKI.ResourcesSpec
@@ -26,5 +27,6 @@ main = defaultMain $ testGroup "All tests" [
         rtrGroup,
         httpSpec,
         slurmGroup,
-        loggingSpec
+        loggingSpec,
+        diffGroup
     ]  

--- a/test/src/RPKI/Orphans.hs
+++ b/test/src/RPKI/Orphans.hs
@@ -275,6 +275,10 @@ instance Arbitrary SplPayload where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+instance Arbitrary SplN where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
 instance Arbitrary ASN where
     arbitrary = genericArbitrary
     shrink = genericShrink

--- a/test/src/RPKI/Orphans.hs
+++ b/test/src/RPKI/Orphans.hs
@@ -247,6 +247,14 @@ instance Arbitrary Vrp where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+instance Arbitrary Vrps where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary Roas where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
 instance Arbitrary AscOrderedVrp where
     arbitrary = genericArbitrary
     shrink = genericShrink

--- a/test/src/RPKI/Store/DatabaseSpec.hs
+++ b/test/src/RPKI/Store/DatabaseSpec.hs
@@ -384,7 +384,7 @@ shouldPreserveStateInAppTx io = do
                 addedObject
 
     HU.assertEqual "Root metric should count 2 objects" 
-        (Just $ mempty { added = 2, deleted = 0 })
+        (Just $ (mempty :: RrdpMetric) { added = 2, deleted = 0 })
         (stripTime <$> lookupMetric (newScope "root") (rrdpMetrics topDownMetric))        
 
     HU.assertEqual "Nested metric should count 1 object" 

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -73,6 +73,8 @@ instance Compressable Validations where
     compress = Validations . compress . unValidations
     isEmpty = isEmpty . unValidations
 
+-- delete keys from the map if corresponding values is "empty"
+-- for some definition of empty
 instance Compressable v => Compressable (Map k v) where    
     compress = Map.filter (not . isEmpty) . Map.map compress 
     isEmpty = Map.null

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -5,7 +5,7 @@
 module RPKI.Store.DiffSpec where
 
 import           Data.Set                 (Set)
-import qualified Data.Set                 as Set
+import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import qualified Data.Map.Monoidal.Strict as MonoidalMap
 import           Data.Tuple.Strict
@@ -27,20 +27,50 @@ diffGroup = testGroup "PublicationPoints" [
         QC.testProperty "BGPSecPayload applyDiff works" $ checkDiff @(Set BGPSecPayload),
         QC.testProperty "Trace applyDiff works" $ checkDiff @(Set Trace),
 
-        QC.testProperty "Roas applyDiff works" $ \(before, after) -> let
-                noEmptyOnes = Roas . MonoidalMap.filter (not . MonoidalMap.null) . unRoas    
-            in checkDiff (noEmptyOnes before, noEmptyOnes after),
+        QC.testProperty "Roas applyDiff works" $ \(before :: Roas, after :: Roas) -> 
+            checkDiff before after,
 
-        QC.testProperty "Vrps applyDiff works" $ \(before, after) -> let
-                noEmptyOnes = Vrps . MonoidalMap.filter (not . Set.null) . unVrps    
-            in checkDiff (noEmptyOnes before, noEmptyOnes after),
+        QC.testProperty "Vrps applyDiff works" $ \(before :: Vrps, after :: Vrps) ->
+            checkDiff before after,
 
-        QC.testProperty "Validations applyDiff works" $ \(before, after) -> let
-                noEmptyOnes = Validations . Map.filter (not . Set.null) . unValidations    
-            in checkDiff (noEmptyOnes before, noEmptyOnes after)
+        QC.testProperty "Validations applyDiff works" $ \(before :: Validations, after :: Validations) -> 
+            checkDiff before after
     ]
 
 
-checkDiff :: (Eq a, Diffable a) => (a, a) -> Bool
-checkDiff (before, after) = 
-    applyDiff before (makeDiff before after) == after
+checkDiff :: (Eq a, Shrinkable a, Diffable a) => a -> a -> Bool
+checkDiff before after = 
+    if (applyDiff before (makeDiff before after) == after)
+        then True
+        else let 
+            bShrunk = shrink before
+            aShrunk = shrink after
+        in applyDiff bShrunk (makeDiff bShrunk aShrunk) == aShrunk        
+
+class Shrinkable a where 
+    shrink :: a -> a     
+    shrink = id
+    isEmpty :: a -> Bool
+    isEmpty _ = False
+
+instance Shrinkable (Set v)
+
+instance Shrinkable Roas where    
+    shrink = Roas . shrink . unRoas
+    isEmpty = isEmpty . unRoas
+
+instance Shrinkable Vrps where    
+    shrink = Vrps . shrink . unVrps
+    isEmpty = isEmpty . unVrps
+
+instance Shrinkable Validations where    
+    shrink = Validations . shrink . unValidations
+    isEmpty = isEmpty . unValidations
+
+instance Shrinkable v => Shrinkable (Map k v) where    
+    shrink = Map.filter (not . isEmpty) . Map.map shrink 
+    isEmpty = Map.null
+
+instance Shrinkable v => Shrinkable (MonoidalMap.MonoidalMap k v) where    
+    shrink = MonoidalMap.filter (not . isEmpty) . MonoidalMap.map shrink 
+    isEmpty = MonoidalMap.null

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -4,7 +4,9 @@
 
 module RPKI.Store.DiffSpec where
 
+import           Data.Text
 import           Data.Set                 (Set)
+import           Data.Map.Strict          (Map)
 import           Data.Tuple.Strict
 
 import           Test.Tasty                 hiding (after)

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -21,7 +21,6 @@ import           RPKI.Domain
 import           RPKI.Store.Diff
 
 
-
 diffGroup :: TestTree
 diffGroup = localOption (QC.QuickCheckTests 300) $ testGroup "Diffs" [        
         QC.testProperty "Aspa applyDiff works" $ checkDiff @(Set Aspa),
@@ -49,13 +48,13 @@ checkDiff before after =
             -- The only reasons tests are not allowed to pass is
             -- empty map values that will be filtered out by the diff 
             -- procedure.
-            bShrunk = shrink before
-            aShrunk = shrink after
+            bShrunk = compress before
+            aShrunk = compress after
         in applyDiff bShrunk (makeDiff bShrunk aShrunk) == aShrunk        
 
 class Compressable a where 
-    shrink :: a -> a     
-    shrink = id
+    compress :: a -> a     
+    compress = id
     isEmpty :: a -> Bool
     isEmpty _ = False
 
@@ -63,21 +62,21 @@ instance Compressable (Set v) where
     isEmpty = Set.null
 
 instance Compressable Roas where    
-    shrink = Roas . shrink . unRoas
+    compress = Roas . compress . unRoas
     isEmpty = isEmpty . unRoas
 
 instance Compressable Vrps where    
-    shrink = Vrps . shrink . unVrps
+    compress = Vrps . compress . unVrps
     isEmpty = isEmpty . unVrps
 
 instance Compressable Validations where    
-    shrink = Validations . shrink . unValidations
+    compress = Validations . compress . unValidations
     isEmpty = isEmpty . unValidations
 
 instance Compressable v => Compressable (Map k v) where    
-    shrink = Map.filter (not . isEmpty) . Map.map shrink 
+    compress = Map.filter (not . isEmpty) . Map.map compress 
     isEmpty = Map.null
 
 instance Compressable v => Compressable (MonoidalMap.MonoidalMap k v) where    
-    shrink = MonoidalMap.filter (not . isEmpty) . MonoidalMap.map shrink 
+    compress = MonoidalMap.filter (not . isEmpty) . MonoidalMap.map compress 
     isEmpty = MonoidalMap.null

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -27,8 +27,7 @@ diffGroup = testGroup "PublicationPoints" [
         QC.testProperty "Trace applyDiff works" $ checkDiff @(Set Trace),
         QC.testProperty "Roas applyDiff works" $ checkDiff @Roas,
         QC.testProperty "Vrps applyDiff works" $ checkDiff @Vrps,
-        QC.testProperty "Validations applyDiff works" $ checkDiff @Validations,
-        QC.testProperty "RawMetric applyDiff works" $ checkDiff @RawMetric
+        QC.testProperty "Validations applyDiff works" $ checkDiff @Validations
     ]
 
 checkDiff :: (Eq a, Diffable a) => (a, a) -> Bool

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -5,6 +5,7 @@
 module RPKI.Store.DiffSpec where
 
 import           Data.Set                 (Set)
+import qualified Data.Set                 as Set
 import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import qualified Data.Map.Monoidal.Strict as MonoidalMap
@@ -19,8 +20,10 @@ import           RPKI.Reporting
 import           RPKI.Domain
 import           RPKI.Store.Diff
 
+
+
 diffGroup :: TestTree
-diffGroup = testGroup "PublicationPoints" [
+diffGroup = localOption (QC.QuickCheckTests 300) $ testGroup "Diffs" [        
         QC.testProperty "Aspa applyDiff works" $ checkDiff @(Set Aspa),
         QC.testProperty "SplN applyDiff works" $ checkDiff @(Set SplN),
         QC.testProperty "Gbr applyDiff works" $ checkDiff @(Set (T2 Hash Gbr)),
@@ -38,39 +41,43 @@ diffGroup = testGroup "PublicationPoints" [
     ]
 
 
-checkDiff :: (Eq a, Shrinkable a, Diffable a) => a -> a -> Bool
+checkDiff :: (Eq a, Compressable a, Diffable a) => a -> a -> Bool
 checkDiff before after = 
     if (applyDiff before (makeDiff before after) == after)
         then True
         else let 
+            -- The only reasons tests are not allowed to pass is
+            -- empty map values that will be filtered out by the diff 
+            -- procedure.
             bShrunk = shrink before
             aShrunk = shrink after
         in applyDiff bShrunk (makeDiff bShrunk aShrunk) == aShrunk        
 
-class Shrinkable a where 
+class Compressable a where 
     shrink :: a -> a     
     shrink = id
     isEmpty :: a -> Bool
     isEmpty _ = False
 
-instance Shrinkable (Set v)
+instance Compressable (Set v) where    
+    isEmpty = Set.null
 
-instance Shrinkable Roas where    
+instance Compressable Roas where    
     shrink = Roas . shrink . unRoas
     isEmpty = isEmpty . unRoas
 
-instance Shrinkable Vrps where    
+instance Compressable Vrps where    
     shrink = Vrps . shrink . unVrps
     isEmpty = isEmpty . unVrps
 
-instance Shrinkable Validations where    
+instance Compressable Validations where    
     shrink = Validations . shrink . unValidations
     isEmpty = isEmpty . unValidations
 
-instance Shrinkable v => Shrinkable (Map k v) where    
+instance Compressable v => Compressable (Map k v) where    
     shrink = Map.filter (not . isEmpty) . Map.map shrink 
     isEmpty = Map.null
 
-instance Shrinkable v => Shrinkable (MonoidalMap.MonoidalMap k v) where    
+instance Compressable v => Compressable (MonoidalMap.MonoidalMap k v) where    
     shrink = MonoidalMap.filter (not . isEmpty) . MonoidalMap.map shrink 
     isEmpty = MonoidalMap.null

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -2,27 +2,33 @@
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE RecordWildCards           #-}
 
-
 module RPKI.Store.DiffSpec where
 
 import           Data.Set                 (Set)
+import           Data.Tuple.Strict
 
 import           Test.Tasty                 hiding (after)
 import qualified Test.Tasty.QuickCheck      as QC
 
 import           RPKI.Orphans
 
+import           RPKI.Reporting
 import           RPKI.Domain
 import           RPKI.Store.Diff
 
 diffGroup :: TestTree
 diffGroup = testGroup "PublicationPoints" [
-        QC.testProperty "Aspa applyDiff works" $ checkDiff @Aspa,
-        QC.testProperty "Aspa applyDiff works" $ checkDiff @SplN
+        QC.testProperty "Aspa applyDiff works" $ checkDiff @(Set Aspa),
+        QC.testProperty "SplN applyDiff works" $ checkDiff @(Set SplN),
+        QC.testProperty "Gbr applyDiff works" $ checkDiff @(Set (T2 Hash Gbr)),
+        QC.testProperty "BGPSecPayload applyDiff works" $ checkDiff @(Set BGPSecPayload),
+        QC.testProperty "Trace applyDiff works" $ checkDiff @(Set Trace),
+        QC.testProperty "Roas applyDiff works" $ checkDiff @Roas,
+        QC.testProperty "Vrps applyDiff works" $ checkDiff @Vrps,
+        QC.testProperty "Validations applyDiff works" $ checkDiff @Validations,
+        QC.testProperty "RawMetric applyDiff works" $ checkDiff @RawMetric
     ]
 
-checkDiff :: Ord a => (Set a, Set a) -> Bool
-checkDiff (before, after) = let 
-    diff = makeSetDiff before after
-    after' = applySetDiff before diff
-    in after' == after
+checkDiff :: (Eq a, Diffable a) => (a, a) -> Bool
+checkDiff (before, after) = 
+    applyDiff before (makeDiff before after) == after

--- a/test/src/RPKI/Store/DiffSpec.hs
+++ b/test/src/RPKI/Store/DiffSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedLabels          #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RecordWildCards           #-}
+
+
+module RPKI.Store.DiffSpec where
+
+import           Data.Set                 (Set)
+
+import           Test.Tasty                 hiding (after)
+import qualified Test.Tasty.QuickCheck      as QC
+
+import           RPKI.Orphans
+
+import           RPKI.Domain
+import           RPKI.Store.Diff
+
+diffGroup :: TestTree
+diffGroup = testGroup "PublicationPoints" [
+        QC.testProperty "Aspa applyDiff works" $ checkDiff @Aspa,
+        QC.testProperty "Aspa applyDiff works" $ checkDiff @SplN
+    ]
+
+checkDiff :: Ord a => (Set a, Set a) -> Bool
+checkDiff (before, after) = let 
+    diff = makeSetDiff before after
+    after' = applySetDiff before diff
+    in after' == after


### PR DESCRIPTION
Add diff-based storage for all payloads. That would allow to store much less redundant data for every version and to store much more versions in the same disk space. This is beneficial for saving space in case of frequent re-validations.