### PR TITLE
Make Instant a nanosecond Int64

### DIFF
--- a/src/RPKI/AppState.hs
+++ b/src/RPKI/AppState.hs
@@ -123,10 +123,10 @@ getOrCreateWorldVerion AppState {..} =
         maybe newWorldVersion pure <$> readTVar world
 
 versionToInstant :: WorldVersion -> Instant
-versionToInstant (WorldVersion nanos) = fromNanoseconds nanos
+versionToInstant (WorldVersion nanos) = Instant nanos
 
 instantToVersion :: Instant -> WorldVersion
-instantToVersion = WorldVersion . toNanoseconds
+instantToVersion (Instant nanos) = WorldVersion nanos
 
 -- Block on version updates
 waitForNewVersion :: AppState -> WorldVersion -> STM (WorldVersion, RtrPayloads)

--- a/src/RPKI/Domain.hs
+++ b/src/RPKI/Domain.hs
@@ -345,7 +345,7 @@ instance WithHash (CMSBasedObject a) where
 
 instance {-# OVERLAPPING #-} WithValidityPeriod (CMSBasedObject a) where
     getValidityPeriod CMSBasedObject {..} = 
-        bimap Instant Instant $ X509.certValidity 
+        bimap newInstant newInstant $ X509.certValidity 
             $ cwsX509certificate $ getCertWithSignature 
             $ getEEResourceCert $ unCMS cmsPayload 
 
@@ -377,7 +377,7 @@ instance WithSKI (CMSBasedObject a) where
 
 instance WithRawResourceCertificate a => WithValidityPeriod a where
     getValidityPeriod cert = 
-        bimap Instant Instant $ X509.certValidity 
+        bimap newInstant newInstant $ X509.certValidity 
             $ cwsX509certificate $ getCertWithSignature $ getRawCert cert
 
 instance {-# OVERLAPPING #-} WithRawResourceCertificate a => WithSerial a where
@@ -804,7 +804,7 @@ instance Monoid EarliestToExpire where
     -- It is 2262-04-11 23:47:16.000Z, it's 
     -- 1) far enough to set it as "later that anything else"
     -- 2) Anything bigger than that wraps around to the year 1677
-    mempty = EarliestToExpire $ fromNanoseconds $ 1000_000_000 * 9_223_372_036
+    mempty = EarliestToExpire $ Instant $ 1000_000_000 * 9_223_372_036
 
 -- Small utility functions that don't have anywhere else to go
 

--- a/src/RPKI/Http/Dto.hs
+++ b/src/RPKI/Http/Dto.hs
@@ -235,8 +235,8 @@ objectToDto = \case
 
             certSignatureAlg = Text.pack $ show $ X509.certSignatureAlg x509cert
 
-            notValidBefore = Instant $ fst $ X509.certValidity x509cert
-            notValidAfter  = Instant $ snd $ X509.certValidity x509cert
+            notValidBefore = newInstant $ fst $ X509.certValidity x509cert
+            notValidAfter  = newInstant $ snd $ X509.certValidity x509cert
 
             pubKey = case X509.certPubKey x509cert of
                         X509.PubKeyRSA RSA.PublicKey {..} -> Right $ let

--- a/src/RPKI/Orphans/Json.hs
+++ b/src/RPKI/Orphans/Json.hs
@@ -95,7 +95,7 @@ instance ToJSON Instant where
 
 -- TODO Maybe it's not the best thing to do 
 instance ToJSON DateTime where
-    toJSON = toJSON . show . Instant
+    toJSON = toJSON . logPrint
 
 instance ToJSON RpkiURL where
     toJSON = toJSON . getURL
@@ -312,7 +312,7 @@ instance ToJSON Attribute where
             ]            
         SigningTime dt _ -> Json.object [
                 "type" .= ("SigningTime" :: Text),
-                "value" .= instantDateFormat (Instant dt)                
+                "value" .= instantDateFormat (newInstant dt)                
             ]
         BinarySigningTime bst -> Json.object [
                 "type" .= ("BinarySigningTime" :: Text),

--- a/src/RPKI/Parse/Internal/CRL.hs
+++ b/src/RPKI/Parse/Internal/CRL.hs
@@ -67,8 +67,8 @@ parseCrl bs = do
             let encoded = encodeASN1' DER $ [Start Sequence] <> asns <> [End Sequence]
 
             let mkSignCRL crlNumber' = SignCRL 
-                        (Instant thisUpdate)
-                        (Instant <$> nextUpdate)
+                        (newInstant thisUpdate)
+                        (newInstant <$> nextUpdate)
                         (SignatureAlgorithmIdentifier signatureId) 
                         signatureVal (toShortBS encoded) 
                         crlNumber' 

--- a/src/RPKI/Parse/Internal/MFT.hs
+++ b/src/RPKI/Parse/Internal/MFT.hs
@@ -38,7 +38,7 @@ parseMft bs = do
                             -- TODO translate to UTC       
                             mn <- makeMftNumber manifestNumber        
                             pure $ Manifest mn hashAlg' 
-                                (Instant thisUpdateTime') (Instant nextUpdateTime') entries
+                                (newInstant thisUpdateTime') (newInstant nextUpdateTime') entries
 
                     -- TODO Check version?
                     (IntVal version,
@@ -52,7 +52,7 @@ parseMft bs = do
                             -- TODO translate to UTC
                             mn <- makeMftNumber manifestNumber
                             pure $ Manifest mn hashAlg' 
-                                (Instant thisUpdateTime') (Instant nextUpdateTime') entries
+                                (newInstant thisUpdateTime') (newInstant nextUpdateTime') entries
 
                     s -> throwParseError $ "Unexpected manifest content: " ++ show s
 

--- a/src/RPKI/Store/Database.hs
+++ b/src/RPKI/Store/Database.hs
@@ -69,7 +69,7 @@ import           RPKI.Time
 -- It is brittle and inconvenient, but so far seems to be 
 -- the only realistic option.
 currentDatabaseVersion :: Integer
-currentDatabaseVersion = 43
+currentDatabaseVersion = 44
 
 -- Some constant keys
 databaseVersionKey, validatedByVersionKey :: Text

--- a/src/RPKI/Time.hs
+++ b/src/RPKI/Time.hs
@@ -20,7 +20,7 @@ import           RPKI.Store.Base.Serialisation
 import           RPKI.Orphans.Store
 
 
-newtype Instant = Instant DateTime
+newtype Instant = Instant Int64
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (TheBinary, NFData)
 
@@ -38,8 +38,11 @@ instance TimeFormat LogDateFormat where
         dash = Format_Text '-'
         colon = Format_Text ':'
 
+logPrint :: DateTime -> String
+logPrint = timePrint LogDateFormat
+
 instance Show Instant where
-    show (Instant d) = timePrint LogDateFormat d
+    show (Instant d) = logPrint (fromNanoseconds d)
 
 -- | Current time that is to be passed into the environment of validating functions
 newtype Now = Now { unNow :: Instant }
@@ -63,8 +66,11 @@ instance Show TimeMs where
 instance Show CPUTime where 
     show (CPUTime ms) = show ms
 
+newInstant :: DateTime -> Instant
+newInstant = Instant . toNanos
+
 thisInstant :: MonadIO m => m Now
-thisInstant = Now . Instant <$> liftIO dateCurrent
+thisInstant = Now . Instant . toNanos <$> liftIO dateCurrent
 
 getCpuTime :: MonadIO m => m CPUTime
 getCpuTime = do 
@@ -72,23 +78,20 @@ getCpuTime = do
     pure $! CPUTime $ picos `div` 1000_000_000
 
 durationMs :: Instant -> Instant -> TimeMs
-durationMs (Instant begin) (Instant end) = let 
-    (Seconds s, NanoSeconds ns) = timeDiffP end begin    
-    totalNanos = s * nanosPerSecond + ns
-    in fromIntegral $! totalNanos `div` nanosPerMicrosecond 
+durationMs (Instant begin) (Instant end) = 
+    fromIntegral $ (end - begin) `div` nanosPerMicrosecond 
     
 timed :: MonadIO m => m a -> m (a, Int64)
 timed action = do 
     Now (Instant begin) <- thisInstant
     !z <- action
-    Now (Instant end) <- thisInstant
-    let (Seconds s, NanoSeconds ns) = timeDiffP end begin
-    pure $! (z, s * nanosPerSecond + ns)
+    Now (Instant end) <- thisInstant    
+    pure (z, end - begin)
 
 timedMS :: MonadIO m => m a -> m (a, TimeMs)
 timedMS action = do 
     (!z, ns) <- timed action   
-    pure $! (z, fromIntegral $! ns `div` nanosPerMicrosecond)
+    pure (z, fromIntegral $ ns `div` nanosPerMicrosecond)
 
 nanosPerSecond :: Num p => p
 nanosPerSecond = 1000_000_000
@@ -99,22 +102,22 @@ nanosPerMicrosecond = 1000_000
 {-# INLINE nanosPerMicrosecond #-}
 
 toNanoseconds :: Instant -> Int64
-toNanoseconds (Instant instant) = 
-    nanosPerSecond * seconds + nanos
-    where 
-        ElapsedP (Elapsed (Seconds seconds)) (NanoSeconds nanos) = timeGetElapsedP instant
+toNanoseconds (Instant instant) = instant
 
-asSeconds :: Instant -> Int64
-asSeconds (Instant instant) = seconds
-    where 
-        ElapsedP (Elapsed (Seconds seconds)) _ = timeGetElapsedP instant
+toNanos :: DateTime -> Int64
+toNanos d = nanosPerSecond * seconds + nanos
+  where 
+    ElapsedP (Elapsed (Seconds seconds)) (NanoSeconds nanos) = timeGetElapsedP d
 
-fromNanoseconds :: Int64 -> Instant
+asSeconds :: Instant -> Seconds
+asSeconds (Instant instant) = Seconds $ fromIntegral $ instant `div` nanosPerSecond
+
+fromNanoseconds :: Int64 -> DateTime
 fromNanoseconds totalNanos =    
-    Instant $ timeConvert elapsed
-    where 
-        elapsed = ElapsedP (Elapsed (Seconds seconds)) (NanoSeconds nanos)
-        (seconds, nanos) = totalNanos `divMod` nanosPerSecond     
+    timeConvert elapsed
+  where 
+    elapsed = ElapsedP (Elapsed (Seconds seconds)) (NanoSeconds nanos)
+    (seconds, nanos) = totalNanos `divMod` nanosPerSecond     
 
 closeEnoughMoments :: Earlier -> Later -> Seconds -> Bool
 closeEnoughMoments earlierInstant laterInstant intervalSeconds = 
@@ -125,13 +128,14 @@ newtype Later = Later Instant
 
 instantDiff :: Earlier -> Later -> Seconds
 instantDiff (Earlier (Instant earlierInstant)) (Later (Instant laterInstant)) = 
-    timeDiff laterInstant earlierInstant  
+    Seconds $ (laterInstant - earlierInstant) `div` nanosPerSecond
 
 momentAfter :: Instant -> Seconds -> Instant
-momentAfter (Instant moment) seconds = Instant $ timeAdd moment seconds
+momentAfter (Instant moment) (Seconds seconds) = 
+    Instant $ moment + seconds * nanosPerSecond
 
 instantDateFormat :: Instant -> String
-instantDateFormat (Instant d) = timePrint format d
+instantDateFormat (Instant d) = timePrint format (fromNanoseconds d)
   where 
     format = TimeFormatString [
             Format_Year, dash, Format_Month2, dash, Format_Day2,
@@ -143,7 +147,7 @@ instantDateFormat (Instant d) = timePrint format d
     colon = Format_Text ':'   
 
 instantTimeFormat :: Instant -> String
-instantTimeFormat (Instant d) = timePrint format d
+instantTimeFormat (Instant d) = timePrint format (fromNanoseconds d)
   where 
     format = TimeFormatString [            
             Format_Hour, colon, Format_Minute, colon, Format_Second,
@@ -163,4 +167,4 @@ asCpuTime :: Seconds -> CPUTime
 asCpuTime (Seconds s) = CPUTime $ fromIntegral $ s * 1000
 
 isoFormat :: Instant -> String
-isoFormat (Instant t) = timePrint ISO8601_DateAndTime t
+isoFormat (Instant t) = timePrint ISO8601_DateAndTime (fromNanoseconds t)

--- a/src/RPKI/Time.hs
+++ b/src/RPKI/Time.hs
@@ -109,8 +109,8 @@ toNanos d = nanosPerSecond * seconds + nanos
   where 
     ElapsedP (Elapsed (Seconds seconds)) (NanoSeconds nanos) = timeGetElapsedP d
 
-asSeconds :: Instant -> Seconds
-asSeconds (Instant instant) = Seconds $ fromIntegral $ instant `div` nanosPerSecond
+asSeconds :: Instant -> Int64
+asSeconds (Instant instant) = fromIntegral $ instant `div` nanosPerSecond
 
 fromNanoseconds :: Int64 -> DateTime
 fromNanoseconds totalNanos =    

--- a/src/RPKI/UniqueId.hs
+++ b/src/RPKI/UniqueId.hs
@@ -8,4 +8,4 @@ thisExecutableVersion :: ExecutableVersion
 thisExecutableVersion = ExecutableVersion $ rpkiProverVersion <> " " <> 
     -- The content is to be updated by the 'src-hash' script 
     -- that calculates hash of the source tree and configuration/build files     
-    "srcHash#a3371045a05f63c04877517a50f7223b120828a76da80e8b5c6121db5faf8898#srcHash"
+    "srcHash#7dd29097ce5875a90660fe55f17f9fee798522f80ff4e54a5bfda5e8db601caf#srcHash"

--- a/src/RPKI/UniqueId.hs
+++ b/src/RPKI/UniqueId.hs
@@ -8,4 +8,4 @@ thisExecutableVersion :: ExecutableVersion
 thisExecutableVersion = ExecutableVersion $ rpkiProverVersion <> " " <> 
     -- The content is to be updated by the 'src-hash' script 
     -- that calculates hash of the source tree and configuration/build files     
-    "srcHash#270a7ffbbb37f8d0ebbeac110ba0f404ec6c4d21c2308cf461ea9bdfd2c641e2#srcHash"
+    "srcHash#a3371045a05f63c04877517a50f7223b120828a76da80e8b5c6121db5faf8898#srcHash"

--- a/src/RPKI/Validation/ObjectValidation.hs
+++ b/src/RPKI/Validation/ObjectValidation.hs
@@ -155,7 +155,7 @@ validateTaCertAKI taCert u =
 -- 
 chooseTaCert :: CaCerObject -> CaCerObject -> PureValidatorT CaCerObject
 chooseTaCert cert cachedCert = do
-    let validities = bimap Instant Instant . certValidity . cwsX509certificate . getCertWithSignature
+    let validities = bimap newInstant newInstant . certValidity . cwsX509certificate . getCertWithSignature
     let (notBefore, notAfter) = validities cert
     let (cachedNotBefore, cachedNotAfter) = validities cachedCert
     let bothValidities = TACertValidities {..}

--- a/src/RPKI/Workflow.hs
+++ b/src/RPKI/Workflow.hs
@@ -1237,8 +1237,8 @@ runConcurrentlyIfPossible logger taskType Tasks {..} action = do
 
 
 versionIsOld :: Instant -> Seconds -> WorldVersion -> Bool
-versionIsOld now period (WorldVersion nanos) =
-    let validatedAt = fromNanoseconds nanos
+versionIsOld now period version =
+    let validatedAt = versionToInstant version
     in not $ closeEnoughMoments (Earlier validatedAt) (Later now) period
 
 


### PR DESCRIPTION
It slightly reduces the size of serialised structures stored in cache (about 10% for manifest shortcuts)